### PR TITLE
feat: 메인 화면 스터디그룹 메뉴 처리, 스터디 상세 화면 수정/ 삭제 

### DIFF
--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -56,6 +56,7 @@ fun WeQuizNavHost(
             onCreateCategoryButtonClick = navController::navigateCreateCategory,
             onCategoryClick = navController::navigateCategory,
             onDeleteStudyGroupSuccess = navController::navigateUp,
+            onLeaveStudyGroupSuccess = navController::navigateUp,
         )
 
         categoryNavGraph(

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -55,6 +55,7 @@ fun WeQuizNavHost(
             onCreateStudySuccess = navController::navigateUp,
             onCreateCategoryButtonClick = navController::navigateCreateCategory,
             onCategoryClick = navController::navigateCategory,
+            onDeleteStudyGroupSuccess = navController::navigateUp,
         )
 
         categoryNavGraph(

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -58,6 +58,7 @@ fun WeQuizNavHost(
             onCategoryClick = navController::navigateCategory,
             onDeleteStudyGroupSuccess = navController::navigateUp,
             onLeaveStudyGroupSuccess = navController::navigateUp,
+            onEditStudyGroupButtonClick = navController::navigateCreateStudy,
         )
 
         categoryNavGraph(

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -53,7 +53,7 @@ fun WeQuizNavHost(
 
         studyNavGraph(
             onNavigationButtonClick = navController::navigateUp,
-            onCreateStudySuccess = navController::navigateUp,
+            onSubmitStudySuccess = navController::navigateUp,
             onCreateCategoryButtonClick = navController::navigateCreateCategory,
             onCategoryClick = navController::navigateCategory,
             onDeleteStudyGroupSuccess = navController::navigateUp,

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -48,6 +48,7 @@ fun WeQuizNavHost(
             onNotificationButtonClick = navController::navigateNotification,
             onCreateStudyButtonClick = navController::navigateCreateStudy,
             onStudyGroupClick = navController::navigateStudy,
+            onEditStudyButtonClick = navController::navigateCreateStudy,
         )
 
         studyNavGraph(

--- a/build-logic/src/main/java/kr/boostcamp_2024/course/build_logic/Firebase.kt
+++ b/build-logic/src/main/java/kr/boostcamp_2024/course/build_logic/Firebase.kt
@@ -14,6 +14,7 @@ internal fun Project.configureFirebase() {
         add("implementation", platform(bom))
         add("implementation", libs.findLibrary("firebase.auth").get())
         add("implementation", libs.findLibrary("firebase.firestore").get())
+        add("implementation", libs.findLibrary("firebase.storage").get())
     }
 
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/di/AppModule.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/di/AppModule.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,6 +21,9 @@ private val Context.weQuizDataStore: DataStore<Preferences> by preferencesDataSt
 object AppModule {
     @Provides
     fun provideFirebaseFireStore() = Firebase.firestore
+
+    @Provides
+    fun provideFirebaseStorage() = Firebase.storage
 
     @Provides
     fun provideWeQuizDataStore(

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/di/RepositoryModule.kt
@@ -9,6 +9,7 @@ import kr.boostcamp_2024.course.data.repository.CategoryRepositoryImpl
 import kr.boostcamp_2024.course.data.repository.NotificationRepositoryImpl
 import kr.boostcamp_2024.course.data.repository.QuestionRepositoryImpl
 import kr.boostcamp_2024.course.data.repository.QuizRepositoryImpl
+import kr.boostcamp_2024.course.data.repository.StorageRepositoryImpl
 import kr.boostcamp_2024.course.data.repository.StudyGroupRepositoryImpl
 import kr.boostcamp_2024.course.data.repository.UserOmrRepositoryImpl
 import kr.boostcamp_2024.course.data.repository.UserRepositoryImpl
@@ -17,6 +18,7 @@ import kr.boostcamp_2024.course.domain.repository.CategoryRepository
 import kr.boostcamp_2024.course.domain.repository.NotificationRepository
 import kr.boostcamp_2024.course.domain.repository.QuestionRepository
 import kr.boostcamp_2024.course.domain.repository.QuizRepository
+import kr.boostcamp_2024.course.domain.repository.StorageRepository
 import kr.boostcamp_2024.course.domain.repository.StudyGroupRepository
 import kr.boostcamp_2024.course.domain.repository.UserOmrRepository
 import kr.boostcamp_2024.course.domain.repository.UserRepository
@@ -63,4 +65,9 @@ abstract class RepositoryModule {
     abstract fun provideAuthRepository(
         authRepositoryImpl: AuthRepositoryImpl,
     ): AuthRepository
+
+    @Binds
+    abstract fun provideStorageRepository(
+        storageRepositoryImpl: StorageRepositoryImpl,
+    ): StorageRepository
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/CategoryRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/CategoryRepositoryImpl.kt
@@ -54,4 +54,11 @@ class CategoryRepositoryImpl @Inject constructor(
             document.update("quizzes", FieldValue.arrayUnion(quizId)).await()
 
         }
+
+    override suspend fun deleteCategories(categoryIds: List<String>): Result<Unit> =
+        runCatching {
+            categoryIds.forEach { categoryId ->
+                categoryCollectionRef.document(categoryId).delete().await()
+            }
+        }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/NotificationRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/NotificationRepositoryImpl.kt
@@ -36,4 +36,12 @@ class NotificationRepositoryImpl @Inject constructor(
             )
             notificationCollectionRef.add(notification).await()
         }
+
+    override suspend fun deleteNotificationByStudyGroupId(studyGroupId: String): Result<Unit> =
+        runCatching {
+            notificationCollectionRef.whereEqualTo("group_id", studyGroupId).get().await()
+                .forEach { document ->
+                    document.reference.delete().await()
+                }
+        }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuestionRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuestionRepositoryImpl.kt
@@ -29,15 +29,15 @@ class QuestionRepositoryImpl @Inject constructor(
         requireNotNull(response).toVO(questionId)
     }
 
-    override suspend fun createQuestion(questionCreationInfo: QuestionCreationInfo): Result<String> = runCatching {
-        val document = questionCollectionRef.add(questionCreationInfo.toDTO()).await()
-        document.id
-    }
+    override suspend fun createQuestion(questionCreationInfo: QuestionCreationInfo): Result<String> =
+        runCatching {
+            val document = questionCollectionRef.add(questionCreationInfo.toDTO()).await()
+            document.id
+        }
 
     override suspend fun deleteQuestions(questionIds: List<String>): Result<Unit> = runCatching {
         questionIds.forEach { questionId ->
             questionCollectionRef.document(questionId).delete().await()
         }
-        return Result.success(Unit)
     }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuestionRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuestionRepositoryImpl.kt
@@ -33,4 +33,11 @@ class QuestionRepositoryImpl @Inject constructor(
         val document = questionCollectionRef.add(questionCreationInfo.toDTO()).await()
         document.id
     }
+
+    override suspend fun deleteQuestions(questionIds: List<String>): Result<Unit> = runCatching {
+        questionIds.forEach { questionId ->
+            questionCollectionRef.document(questionId).delete().await()
+        }
+        return Result.success(Unit)
+    }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
@@ -56,4 +56,11 @@ class QuizRepositoryImpl @Inject constructor(
                 .update("user_omrs", FieldValue.arrayUnion(userOmrId))
                 .await()
         }
+
+    override suspend fun deleteQuizzes(quizIds: List<String>): Result<Unit> =
+        runCatching {
+            quizIds.forEach { quizId ->
+                quizCollectionRef.document(quizId).delete().await()
+            }
+        }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StorageRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StorageRepositoryImpl.kt
@@ -1,11 +1,8 @@
 package kr.boostcamp_2024.course.data.repository
 
-import android.util.Log
-import androidx.core.net.toUri
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
 import kr.boostcamp_2024.course.domain.repository.StorageRepository
-import java.time.LocalDateTime
 import java.util.UUID
 import javax.inject.Inject
 
@@ -14,18 +11,24 @@ class StorageRepositoryImpl @Inject constructor(
 ) : StorageRepository {
     private val storageRef = storage.reference
 
-    override suspend fun uploadImage(imageUri: String): Result<String> = runCatching {
-        val startTime = LocalDateTime.now()
-
+    override suspend fun uploadImage(imageByteArray: ByteArray): Result<String> = runCatching {
         val uuid = UUID.randomUUID().toString()
         val fileRef = storageRef.child(uuid)
 
-        fileRef.putFile(imageUri.toUri()).await()
-
-        val endTime = LocalDateTime.now()
-        Log.d("startTime", startTime.toString())
-        Log.d("endTime", endTime.toString())
+        fileRef.putBytes(imageByteArray).await()
 
         fileRef.downloadUrl.await().toString()
+    }
+
+    override suspend fun deleteImage(imageUrl: String): Result<Unit> = runCatching {
+        val filePath = extractPathFromUrl(imageUrl)
+        val fileRef = storageRef.child(filePath)
+        fileRef.delete().await()
+    }
+
+    private fun extractPathFromUrl(imageUrl: String): String {
+        val startIndex = imageUrl.indexOf("o/") + 2
+        val endIndex = imageUrl.indexOf("?")
+        return imageUrl.substring(startIndex, endIndex)
     }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StorageRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StorageRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package kr.boostcamp_2024.course.data.repository
+
+import android.util.Log
+import androidx.core.net.toUri
+import com.google.firebase.storage.FirebaseStorage
+import kotlinx.coroutines.tasks.await
+import kr.boostcamp_2024.course.domain.repository.StorageRepository
+import java.time.LocalDateTime
+import java.util.UUID
+import javax.inject.Inject
+
+class StorageRepositoryImpl @Inject constructor(
+    storage: FirebaseStorage,
+) : StorageRepository {
+    private val storageRef = storage.reference
+
+    override suspend fun uploadImage(imageUri: String): Result<String> = runCatching {
+        val startTime = LocalDateTime.now()
+
+        val uuid = UUID.randomUUID().toString()
+        val fileRef = storageRef.child(uuid)
+
+        fileRef.putFile(imageUri.toUri()).await()
+
+        val endTime = LocalDateTime.now()
+        Log.d("startTime", startTime.toString())
+        Log.d("endTime", endTime.toString())
+
+        fileRef.downloadUrl.await().toString()
+    }
+}

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StorageRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StorageRepositoryImpl.kt
@@ -26,6 +26,14 @@ class StorageRepositoryImpl @Inject constructor(
         fileRef.delete().await()
     }
 
+    override suspend fun deleteImages(imageUrls: List<String>): Result<Unit> = runCatching {
+        imageUrls.forEach { imageUrl ->
+            val filePath = extractPathFromUrl(imageUrl)
+            val fileRef = storageRef.child(filePath)
+            fileRef.delete().await()
+        }
+    }
+
     private fun extractPathFromUrl(imageUrl: String): String {
         val startIndex = imageUrl.indexOf("o/") + 2
         val endIndex = imageUrl.indexOf("?")

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
@@ -4,8 +4,8 @@ import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import kr.boostcamp_2024.course.data.model.StudyGroupDTO
-import kr.boostcamp_2024.course.domain.model.StudyGroupCreationInfo
 import kr.boostcamp_2024.course.domain.model.StudyGroup
+import kr.boostcamp_2024.course.domain.model.StudyGroupCreationInfo
 import kr.boostcamp_2024.course.domain.repository.StudyGroupRepository
 import javax.inject.Inject
 
@@ -48,6 +48,10 @@ class StudyGroupRepositoryImpl @Inject constructor(
     override suspend fun deleteUser(studyGroupId: String, userId: String): Result<Unit> = runCatching {
         val document = studyGroupCollectionRef.document(studyGroupId)
         document.update("users", FieldValue.arrayRemove(userId)).await()
+    }
+
+    override suspend fun deleteStudyGroup(studyGroupId: String): Result<Unit> = runCatching {
+        studyGroupCollectionRef.document(studyGroupId).delete().await()
     }
 
     override suspend fun addCategoryToStudyGroup(studyGroupId: String, categoryId: String): Result<Unit> =

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
@@ -18,6 +18,7 @@ class StudyGroupRepositoryImpl @Inject constructor(
     override suspend fun addStudyGroup(studyGroupCreationInfo: StudyGroupCreationInfo): Result<String> =
         runCatching {
             val request = StudyGroupDTO(
+                studyGroupImageUrl = studyGroupCreationInfo.studyGroupImageUrl,
                 name = studyGroupCreationInfo.name,
                 description = studyGroupCreationInfo.description,
                 maxUserNum = studyGroupCreationInfo.maxUserNum,

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
@@ -73,6 +73,7 @@ class StudyGroupRepositoryImpl @Inject constructor(
     override suspend fun updateStudyGroup(studyGroupId: String, updatedInfo: StudyGroupUpdatedInfo): Result<Unit> =
         runCatching {
             val updatedInfoMap = hashMapOf<String, Any?>(
+                "study_group_image_url" to updatedInfo.studyGroupImageUrl,
                 "name" to updatedInfo.name,
                 "description" to updatedInfo.description,
                 "max_user_num" to updatedInfo.maxUserNum,

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.tasks.await
 import kr.boostcamp_2024.course.data.model.StudyGroupDTO
 import kr.boostcamp_2024.course.domain.model.StudyGroup
 import kr.boostcamp_2024.course.domain.model.StudyGroupCreationInfo
+import kr.boostcamp_2024.course.domain.model.StudyGroupUpdatedInfo
 import kr.boostcamp_2024.course.domain.repository.StudyGroupRepository
 import javax.inject.Inject
 
@@ -66,5 +67,15 @@ class StudyGroupRepositoryImpl @Inject constructor(
             val response = document.toObject(StudyGroupDTO::class.java)
             val studyGroupName = requireNotNull(response?.name)
             studyGroupName
+        }
+
+    override suspend fun updateStudyGroup(studyGroupId: String, updatedInfo: StudyGroupUpdatedInfo): Result<Unit> =
+        runCatching {
+            val updatedInfoMap = hashMapOf<String, Any?>(
+                "name" to updatedInfo.name,
+                "description" to updatedInfo.description,
+                "max_user_num" to updatedInfo.maxUserNum,
+            )
+            studyGroupCollectionRef.document(studyGroupId).update(updatedInfoMap).await()
         }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/UserOmrRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/UserOmrRepositoryImpl.kt
@@ -29,4 +29,11 @@ class UserOmrRepositoryImpl @Inject constructor(
             )
             userOmrCollectionRef.add(userOmrDTO).await().id
         }
+
+    override suspend fun deleteUserOmrs(userOmrIds: List<String>): Result<Unit> =
+        runCatching {
+            userOmrIds.forEach { userOmrId ->
+                userOmrCollectionRef.document(userOmrId).delete().await()
+            }
+        }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/UserRepositoryImpl.kt
@@ -43,6 +43,14 @@ class UserRepositoryImpl @Inject constructor(
             document.update("study_groups", FieldValue.arrayRemove(studyGroupId)).await()
         }
 
+    override suspend fun deleteStudyGroupUsers(userIds: List<String>, studyGroupId: String): Result<Unit> =
+        runCatching {
+            userIds.forEach { userId ->
+                val document = userCollectionRef.document(userId)
+                document.update("study_groups", FieldValue.arrayRemove(studyGroupId)).await()
+            }
+        }
+
     override suspend fun findUserByEmail(email: String): Result<User> =
         runCatching {
             val querySnapshot = userCollectionRef.whereEqualTo("email", email).get().await()

--- a/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizRoundedImage.kt
+++ b/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizRoundedImage.kt
@@ -31,7 +31,7 @@ fun WeQuizLocalRoundedImage(
 @Composable
 fun WeQuizAsyncImage(
     modifier: Modifier = Modifier,
-    imgUrl: String?,
+    imgUrl: Any?,
     placeholder: Painter = painterResource(id = R.drawable.img_error),
     error: Painter = painterResource(id = R.drawable.img_error),
     contentDescription: String?,

--- a/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizValidateTextField.kt
+++ b/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizValidateTextField.kt
@@ -61,9 +61,8 @@ fun WeQuizValidateTextField(
                 text = errorMessage,
                 color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                modifier = Modifier.padding(start = 16.dp, top = 4.dp),
             )
         }
     }
 }
-

--- a/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizValidateTextField.kt
+++ b/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizValidateTextField.kt
@@ -1,0 +1,69 @@
+package kr.boostcamp_2024.course.designsystem.ui.theme.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kr.boostcamp_2024.course.designsystem.R
+
+@Composable
+fun WeQuizValidateTextField(
+    modifier: Modifier = Modifier,
+    label: String,
+    text: String,
+    onTextChanged: (String) -> Unit,
+    placeholder: String,
+    minLines: Int = 1,
+    maxLines: Int = 1,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    errorMessage: String,
+    validFun: (String) -> Boolean,
+) {
+    Column {
+        TextField(
+            value = text,
+            onValueChange = { onTextChanged(it) },
+            modifier = modifier.fillMaxWidth(),
+            textStyle = MaterialTheme.typography.bodyLarge,
+            label = { Text(label) },
+            placeholder = { Text(placeholder) },
+            minLines = minLines,
+            maxLines = maxLines,
+            trailingIcon = {
+                IconButton(
+                    onClick = { onTextChanged("") },
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.outline_cancel_24),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        contentDescription = stringResource(id = R.string.des_clear_text),
+                    )
+                }
+            },
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            isError = !validFun(text),
+        )
+        if (!validFun(text)) {
+            Text(
+                text = errorMessage,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+            )
+        }
+    }
+}
+

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/StudyGroupCreationInfo.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/StudyGroupCreationInfo.kt
@@ -1,6 +1,7 @@
 package kr.boostcamp_2024.course.domain.model
 
 data class StudyGroupCreationInfo(
+    val studyGroupImageUrl: String?,
     val description: String?,
     val maxUserNum: Int,
     val name: String,

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/StudyGroupUpdatedInfo.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/StudyGroupUpdatedInfo.kt
@@ -1,6 +1,7 @@
 package kr.boostcamp_2024.course.domain.model
 
 data class StudyGroupUpdatedInfo(
+    val studyGroupImageUrl: String?,
     val description: String?,
     val maxUserNum: Int,
     val name: String,

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/StudyGroupUpdatedInfo.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/StudyGroupUpdatedInfo.kt
@@ -1,0 +1,7 @@
+package kr.boostcamp_2024.course.domain.model
+
+data class StudyGroupUpdatedInfo(
+    val description: String?,
+    val maxUserNum: Int,
+    val name: String,
+)

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/CategoryRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/CategoryRepository.kt
@@ -12,4 +12,6 @@ interface CategoryRepository {
     suspend fun addQuiz(categoryId: String, quizId: String): Result<Unit>
 
     suspend fun addQuizToCategory(categoryId: String, quizId: String): Result<Unit>
+
+    suspend fun deleteCategories(categoryIds: List<String>): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/NotificationRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/NotificationRepository.kt
@@ -8,4 +8,6 @@ interface NotificationRepository {
     suspend fun deleteNotification(notificationId: String): Result<Unit>
 
     suspend fun addNotification(groupId: String, userId: String): Result<Unit>
+
+    suspend fun deleteNotificationByStudyGroupId(studyGroupId: String): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuestionRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuestionRepository.kt
@@ -11,4 +11,6 @@ interface QuestionRepository {
     suspend fun createQuestion(
         questionCreationInfo: QuestionCreationInfo,
     ): Result<String>
+
+    suspend fun deleteQuestions(questionIds: List<String>): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
@@ -13,4 +13,6 @@ interface QuizRepository {
     suspend fun createQuiz(quizCreateInfo: QuizCreationInfo): Result<String>
 
     suspend fun addUserOmrToQuiz(quizId: String, userOmrId: String): Result<Unit>
+
+    suspend fun deleteQuizzes(quizzes: List<String>): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StorageRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StorageRepository.kt
@@ -1,5 +1,7 @@
 package kr.boostcamp_2024.course.domain.repository
 
 interface StorageRepository {
-    suspend fun uploadImage(imageUri: String): Result<String>
+    suspend fun uploadImage(imageByteArray: ByteArray): Result<String>
+
+    suspend fun deleteImage(imageUrl: String): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StorageRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StorageRepository.kt
@@ -4,4 +4,6 @@ interface StorageRepository {
     suspend fun uploadImage(imageByteArray: ByteArray): Result<String>
 
     suspend fun deleteImage(imageUrl: String): Result<Unit>
+
+    suspend fun deleteImages(imageUrls: List<String>): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StorageRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StorageRepository.kt
@@ -1,0 +1,5 @@
+package kr.boostcamp_2024.course.domain.repository
+
+interface StorageRepository {
+    suspend fun uploadImage(imageUri: String): Result<String>
+}

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StudyGroupRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StudyGroupRepository.kt
@@ -1,7 +1,7 @@
 package kr.boostcamp_2024.course.domain.repository
 
-import kr.boostcamp_2024.course.domain.model.StudyGroupCreationInfo
 import kr.boostcamp_2024.course.domain.model.StudyGroup
+import kr.boostcamp_2024.course.domain.model.StudyGroupCreationInfo
 
 interface StudyGroupRepository {
     suspend fun addStudyGroup(studyGroupCreationInfo: StudyGroupCreationInfo): Result<String>
@@ -15,4 +15,6 @@ interface StudyGroupRepository {
     suspend fun addCategoryToStudyGroup(studyGroupId: String, categoryId: String): Result<Unit>
 
     suspend fun deleteUser(studyGroupId: String, userId: String): Result<Unit>
+
+    suspend fun deleteStudyGroup(studyGroupId: String): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StudyGroupRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StudyGroupRepository.kt
@@ -2,6 +2,7 @@ package kr.boostcamp_2024.course.domain.repository
 
 import kr.boostcamp_2024.course.domain.model.StudyGroup
 import kr.boostcamp_2024.course.domain.model.StudyGroupCreationInfo
+import kr.boostcamp_2024.course.domain.model.StudyGroupUpdatedInfo
 
 interface StudyGroupRepository {
     suspend fun addStudyGroup(studyGroupCreationInfo: StudyGroupCreationInfo): Result<String>
@@ -17,4 +18,6 @@ interface StudyGroupRepository {
     suspend fun deleteUser(studyGroupId: String, userId: String): Result<Unit>
 
     suspend fun deleteStudyGroup(studyGroupId: String): Result<Unit>
+
+    suspend fun updateStudyGroup(studyGroupId: String, updateInfo: StudyGroupUpdatedInfo): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/UserOmrRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/UserOmrRepository.kt
@@ -7,4 +7,6 @@ interface UserOmrRepository {
     suspend fun getUserOmr(userOmrId: String): Result<UserOmr>
 
     suspend fun submitQuiz(userOmrCreationInfo: UserOmrCreationInfo): Result<String>
+
+    suspend fun deleteUserOmrs(userOmrIds: List<String>): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/UserRepository.kt
@@ -12,4 +12,6 @@ interface UserRepository {
     suspend fun addStudyGroupToUser(userId: String, studyId: String): Result<Unit>
 
     suspend fun deleteStudyGroupUser(userId: String, studyGroupId: String): Result<Unit>
+
+    suspend fun deleteStudyGroupUsers(userIds: List<String>, studyGroupId: String): Result<Unit>
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
@@ -30,16 +30,16 @@ import androidx.compose.ui.unit.dp
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizAsyncImage
 import kr.boostcamp_2024.course.domain.model.StudyGroup
-import kr.boostcamp_2024.course.domain.model.User
 import kr.boostcamp_2024.course.main.R
 
 @Composable
 fun StudyGroupItem(
-    currentUser: User?,
+    isOwner: Boolean,
     studyGroup: StudyGroup,
     onStudyGroupClick: (String) -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
-    onLeaveStudyGroupClick: (StudyGroup) -> Unit,
+    onDeleteStudyGroupClick: (StudyGroup) -> Unit,
+    onLeaveStudyGroupClick: (String) -> Unit,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 
@@ -103,12 +103,12 @@ fun StudyGroupItem(
                     contentDescription = stringResource(R.string.des_btn_study_menu),
                 )
 
-                currentUser?.let { user ->
-                    DropdownMenu(
-                        expanded = isExpanded,
-                        onDismissRequest = { isExpanded = false },
-                    ) {
-                        if (user.id == studyGroup.ownerId) {
+                DropdownMenu(
+                    expanded = isExpanded,
+                    onDismissRequest = { isExpanded = false },
+                ) {
+                    when (isOwner) {
+                        true -> {
                             DropdownMenuItem(
                                 text = { Text(text = stringResource(R.string.txt_study_group_menu_edit)) },
                                 onClick = {
@@ -116,14 +116,24 @@ fun StudyGroupItem(
                                     isExpanded = false
                                 },
                             )
+                            DropdownMenuItem(
+                                text = { Text(text = stringResource(R.string.txt_study_group_menu_delete)) },
+                                onClick = {
+                                    onDeleteStudyGroupClick(studyGroup)
+                                    isExpanded = false
+                                },
+                            )
                         }
-                        DropdownMenuItem(
-                            text = { Text(text = stringResource(R.string.txt_study_group_menu_leave)) },
-                            onClick = {
-                                onLeaveStudyGroupClick(studyGroup)
-                                isExpanded = false
-                            },
-                        )
+
+                        false -> {
+                            DropdownMenuItem(
+                                text = { Text(text = stringResource(R.string.txt_study_group_menu_leave)) },
+                                onClick = {
+                                    onLeaveStudyGroupClick(studyGroup.id)
+                                    isExpanded = false
+                                },
+                            )
+                        }
                     }
                 }
             }
@@ -138,13 +148,7 @@ fun StudyGroupItem(
 fun StudyGroupItemPreview() {
     WeQuizTheme {
         StudyGroupItem(
-            currentUser = User(
-                id = "123",
-                email = "email@email.com",
-                name = "오징어",
-                profileUrl = "testUrl",
-                studyGroups = listOf(),
-            ),
+            isOwner = true,
             studyGroup = StudyGroup(
                 id = "1234",
                 name = "일본어 스터디",
@@ -158,6 +162,7 @@ fun StudyGroupItemPreview() {
             onStudyGroupClick = {},
             onEditStudyGroupClick = {},
             onLeaveStudyGroupClick = {},
+            onDeleteStudyGroupClick = {},
         )
     }
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
@@ -30,10 +30,12 @@ import androidx.compose.ui.unit.dp
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizAsyncImage
 import kr.boostcamp_2024.course.domain.model.StudyGroup
+import kr.boostcamp_2024.course.domain.model.User
 import kr.boostcamp_2024.course.main.R
 
 @Composable
 fun StudyGroupItem(
+    currentUser: User?,
     studyGroup: StudyGroup,
     onStudyGroupClick: (String) -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
@@ -101,24 +103,28 @@ fun StudyGroupItem(
                     contentDescription = stringResource(R.string.des_btn_study_menu),
                 )
 
-                DropdownMenu(
-                    expanded = isExpanded,
-                    onDismissRequest = { isExpanded = false },
-                ) {
-                    DropdownMenuItem(
-                        text = { Text(text = "수정") },
-                        onClick = {
-                            onEditStudyGroupClick(studyGroup.id)
-                            isExpanded = false
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(text = "나가기") },
-                        onClick = {
-                            onEditStudyGroupClick(studyGroup.id)
-                            isExpanded = false
-                        },
-                    )
+                currentUser?.let { user ->
+                    DropdownMenu(
+                        expanded = isExpanded,
+                        onDismissRequest = { isExpanded = false },
+                    ) {
+                        if (user.id == studyGroup.ownerId) {
+                            DropdownMenuItem(
+                                text = { Text(text = stringResource(R.string.txt_study_group_menu_edit)) },
+                                onClick = {
+                                    onEditStudyGroupClick(studyGroup.id)
+                                    isExpanded = false
+                                },
+                            )
+                        }
+                        DropdownMenuItem(
+                            text = { Text(text = stringResource(R.string.txt_study_group_menu_leave)) },
+                            onClick = {
+                                onLeaveStudyGroupClick(studyGroup.id)
+                                isExpanded = false
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -132,6 +138,13 @@ fun StudyGroupItem(
 fun StudyGroupItemPreview() {
     WeQuizTheme {
         StudyGroupItem(
+            currentUser = User(
+                id = "123",
+                email = "email@email.com",
+                name = "오징어",
+                profileUrl = "testUrl",
+                studyGroups = listOf(),
+            ),
             studyGroup = StudyGroup(
                 id = "1234",
                 name = "일본어 스터디",

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
@@ -39,7 +39,7 @@ fun StudyGroupItem(
     studyGroup: StudyGroup,
     onStudyGroupClick: (String) -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
-    onLeaveStudyGroupClick: (String) -> Unit,
+    onLeaveStudyGroupClick: (StudyGroup) -> Unit,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 
@@ -120,7 +120,7 @@ fun StudyGroupItem(
                         DropdownMenuItem(
                             text = { Text(text = stringResource(R.string.txt_study_group_menu_leave)) },
                             onClick = {
-                                onLeaveStudyGroupClick(studyGroup.id)
+                                onLeaveStudyGroupClick(studyGroup)
                                 isExpanded = false
                             },
                         )

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/StudyGroupItem.kt
@@ -9,12 +9,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -30,8 +36,10 @@ import kr.boostcamp_2024.course.main.R
 fun StudyGroupItem(
     studyGroup: StudyGroup,
     onStudyGroupClick: (String) -> Unit,
-    onStudyGroupMenuClick: () -> Unit,
+    onEditStudyGroupClick: (String) -> Unit,
+    onLeaveStudyGroupClick: (String) -> Unit,
 ) {
+    var isExpanded by remember { mutableStateOf(false) }
 
     Column {
         Row(
@@ -86,12 +94,32 @@ fun StudyGroupItem(
 
             IconButton(
                 modifier = Modifier.size(24.dp),
-                onClick = onStudyGroupMenuClick,
+                onClick = { isExpanded = isExpanded.not() },
             ) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,
                     contentDescription = stringResource(R.string.des_btn_study_menu),
                 )
+
+                DropdownMenu(
+                    expanded = isExpanded,
+                    onDismissRequest = { isExpanded = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(text = "수정") },
+                        onClick = {
+                            onEditStudyGroupClick(studyGroup.id)
+                            isExpanded = false
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(text = "나가기") },
+                        onClick = {
+                            onEditStudyGroupClick(studyGroup.id)
+                            isExpanded = false
+                        },
+                    )
+                }
             }
         }
 
@@ -115,7 +143,8 @@ fun StudyGroupItemPreview() {
                 categories = emptyList(),
             ),
             onStudyGroupClick = {},
-            onStudyGroupMenuClick = {},
+            onEditStudyGroupClick = {},
+            onLeaveStudyGroupClick = {},
         )
     }
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/navigation/MainNavigation.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/navigation/MainNavigation.kt
@@ -25,6 +25,7 @@ fun NavGraphBuilder.mainNavGraph(
     onNavigationButtonClick: () -> Unit,
     onNotificationButtonClick: () -> Unit,
     onCreateStudyButtonClick: () -> Unit,
+    onEditStudyButtonClick: (String) -> Unit,
     onStudyGroupClick: (String) -> Unit,
 ) {
     composable<MainRoute> {
@@ -32,6 +33,7 @@ fun NavGraphBuilder.mainNavGraph(
             onNotificationButtonClick = onNotificationButtonClick,
             onCreateStudyButtonClick = onCreateStudyButtonClick,
             onStudyGroupClick = onStudyGroupClick,
+            onEditStudyButtonClick = onEditStudyButtonClick,
         )
     }
     composable<NotificationRoute> {

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -58,6 +58,7 @@ fun MainScreen(
     onNotificationButtonClick: () -> Unit,
     onCreateStudyButtonClick: () -> Unit,
     onStudyGroupClick: (String) -> Unit,
+    onEditStudyButtonClick: (String) -> Unit,
     viewModel: MainViewModel = hiltViewModel(),
     snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
@@ -69,7 +70,7 @@ fun MainScreen(
         snackBarHostState = snackBarHostState,
         onNotificationButtonClick = onNotificationButtonClick,
         onCreateStudyButtonClick = onCreateStudyButtonClick,
-        onEditStudyGroupClick = {},
+        onEditStudyGroupClick = onEditStudyButtonClick,
         onDeleteStudyGroupClick = viewModel::deleteStudyGroup,
         onLeaveStudyGroupClick = viewModel::deleteUserFromStudyGroup,
         onStudyGroupClick = onStudyGroupClick,

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -100,7 +100,7 @@ fun MainScreen(
     onNotificationButtonClick: () -> Unit,
     onCreateStudyButtonClick: () -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
-    onLeaveStudyGroupClick: (String) -> Unit,
+    onLeaveStudyGroupClick: (StudyGroup) -> Unit,
     onStudyGroupClick: (String) -> Unit,
 ) {
     val scrollBehavior =
@@ -202,7 +202,7 @@ fun StudyGroupTab(
     studyGroups: List<StudyGroup>,
     onStudyGroupClick: (String) -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
-    onLeaveStudyGroupClick: (String) -> Unit,
+    onLeaveStudyGroupClick: (StudyGroup) -> Unit,
 ) {
     LazyColumn {
         items(items = studyGroups, key = { it.id }) { studyGroup ->

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -2,7 +2,9 @@ package kr.boostcamp_2024.course.main.presentation
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -213,6 +215,10 @@ fun StudyGroupTab(
                 onEditStudyGroupClick = onEditStudyGroupClick,
                 onLeaveStudyGroupClick = onLeaveStudyGroupClick,
             )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
         }
     }
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -70,8 +69,9 @@ fun MainScreen(
         snackBarHostState = snackBarHostState,
         onNotificationButtonClick = onNotificationButtonClick,
         onCreateStudyButtonClick = onCreateStudyButtonClick,
-        onEditStudyGroupClick = viewModel::editStudyGroup,
-        onLeaveStudyGroupClick = viewModel::leaveStudyGroup,
+        onEditStudyGroupClick = {},
+        onDeleteStudyGroupClick = viewModel::deleteStudyGroup,
+        onLeaveStudyGroupClick = viewModel::deleteUserFromStudyGroup,
         onStudyGroupClick = onStudyGroupClick,
     )
 
@@ -91,6 +91,10 @@ fun MainScreen(
             viewModel.shownErrorMessage()
         }
     }
+
+    LaunchedEffect(Unit) {
+        viewModel.loadCurrentUser()
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -102,12 +106,12 @@ fun MainScreen(
     onNotificationButtonClick: () -> Unit,
     onCreateStudyButtonClick: () -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
-    onLeaveStudyGroupClick: (StudyGroup) -> Unit,
+    onDeleteStudyGroupClick: (StudyGroup) -> Unit,
+    onLeaveStudyGroupClick: (String) -> Unit,
     onStudyGroupClick: (String) -> Unit,
 ) {
     val scrollBehavior =
         TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
-    val coroutineScope = rememberCoroutineScope()
 
     var state by rememberSaveable { mutableIntStateOf(0) }
     val titles = stringArrayResource(R.array.main_tabs_titles)
@@ -187,6 +191,7 @@ fun MainScreen(
                         studyGroups = studyGroups,
                         onStudyGroupClick = onStudyGroupClick,
                         onEditStudyGroupClick = onEditStudyGroupClick,
+                        onDeleteStudyGroupClick = onDeleteStudyGroupClick,
                         onLeaveStudyGroupClick = onLeaveStudyGroupClick,
                     )
                 }
@@ -204,15 +209,17 @@ fun StudyGroupTab(
     studyGroups: List<StudyGroup>,
     onStudyGroupClick: (String) -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
-    onLeaveStudyGroupClick: (StudyGroup) -> Unit,
+    onDeleteStudyGroupClick: (StudyGroup) -> Unit,
+    onLeaveStudyGroupClick: (String) -> Unit,
 ) {
     LazyColumn {
         items(items = studyGroups, key = { it.id }) { studyGroup ->
             StudyGroupItem(
-                currentUser = currentUser,
+                isOwner = (studyGroup.ownerId == currentUser?.id),
                 studyGroup = studyGroup,
                 onStudyGroupClick = onStudyGroupClick,
                 onEditStudyGroupClick = onEditStudyGroupClick,
+                onDeleteStudyGroupClick = onDeleteStudyGroupClick,
                 onLeaveStudyGroupClick = onLeaveStudyGroupClick,
             )
         }
@@ -253,6 +260,7 @@ fun MainScreenPreview() {
             onNotificationButtonClick = {},
             onCreateStudyButtonClick = {},
             onStudyGroupClick = {},
+            onDeleteStudyGroupClick = {},
         )
     }
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.coroutines.launch
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizImageLargeTopAppBar
 import kr.boostcamp_2024.course.domain.model.StudyGroup
@@ -69,6 +68,8 @@ fun MainScreen(
         snackBarHostState = snackBarHostState,
         onNotificationButtonClick = onNotificationButtonClick,
         onCreateStudyButtonClick = onCreateStudyButtonClick,
+        onEditStudyGroupClick = viewModel::editStudyGroup,
+        onLeaveStudyGroupClick = viewModel::leaveStudyGroup,
         onStudyGroupClick = onStudyGroupClick,
     )
 
@@ -98,6 +99,8 @@ fun MainScreen(
     snackBarHostState: SnackbarHostState,
     onNotificationButtonClick: () -> Unit,
     onCreateStudyButtonClick: () -> Unit,
+    onEditStudyGroupClick: (String) -> Unit,
+    onLeaveStudyGroupClick: (String) -> Unit,
     onStudyGroupClick: (String) -> Unit,
 ) {
     val scrollBehavior =
@@ -180,11 +183,8 @@ fun MainScreen(
                     StudyGroupTab(
                         studyGroups = studyGroups,
                         onStudyGroupClick = onStudyGroupClick,
-                        onStudyGroupMenuClick = {
-                            coroutineScope.launch {
-                                snackBarHostState.showSnackbar("추후 제공될 기능입니다.")
-                            }
-                        },
+                        onEditStudyGroupClick = onEditStudyGroupClick,
+                        onLeaveStudyGroupClick = onLeaveStudyGroupClick,
                     )
                 }
 
@@ -199,14 +199,16 @@ fun MainScreen(
 fun StudyGroupTab(
     studyGroups: List<StudyGroup>,
     onStudyGroupClick: (String) -> Unit,
-    onStudyGroupMenuClick: () -> Unit,
+    onEditStudyGroupClick: (String) -> Unit,
+    onLeaveStudyGroupClick: (String) -> Unit,
 ) {
     LazyColumn {
         items(items = studyGroups, key = { it.id }) { studyGroup ->
             StudyGroupItem(
                 studyGroup = studyGroup,
                 onStudyGroupClick = onStudyGroupClick,
-                onStudyGroupMenuClick = onStudyGroupMenuClick,
+                onEditStudyGroupClick = onEditStudyGroupClick,
+                onLeaveStudyGroupClick = onLeaveStudyGroupClick,
             )
         }
     }
@@ -237,6 +239,8 @@ fun MainScreenPreview() {
                 ),
             ),
             snackBarHostState = SnackbarHostState(),
+            onEditStudyGroupClick = {},
+            onLeaveStudyGroupClick = {},
             onNotificationButtonClick = {},
             onCreateStudyButtonClick = {},
             onStudyGroupClick = {},

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -181,6 +181,7 @@ fun MainScreen(
             when (state) {
                 0 -> {
                     StudyGroupTab(
+                        currentUser = currentUser,
                         studyGroups = studyGroups,
                         onStudyGroupClick = onStudyGroupClick,
                         onEditStudyGroupClick = onEditStudyGroupClick,
@@ -197,6 +198,7 @@ fun MainScreen(
 
 @Composable
 fun StudyGroupTab(
+    currentUser: User?,
     studyGroups: List<StudyGroup>,
     onStudyGroupClick: (String) -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
@@ -205,6 +207,7 @@ fun StudyGroupTab(
     LazyColumn {
         items(items = studyGroups, key = { it.id }) { studyGroup ->
             StudyGroupItem(
+                currentUser = currentUser,
                 studyGroup = studyGroup,
                 onStudyGroupClick = onStudyGroupClick,
                 onEditStudyGroupClick = onEditStudyGroupClick,

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
@@ -99,20 +99,7 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun editStudyGroup(studyGroupId: String) {
-
-    }
-
-    fun leaveStudyGroup(studyGroup: StudyGroup) {
-        uiState.value.currentUser?.let { user ->
-            when (studyGroup.ownerId == user.id) {
-                true -> removeStudyGroup(studyGroup)
-                false -> removeUserFromStudyGroup(user.id, studyGroup.id)
-            }
-        }
-    }
-
-    private fun removeStudyGroup(studyGroup: StudyGroup) {
+    fun deleteStudyGroup(studyGroup: StudyGroup) {
         viewModelScope.launch {
             categoryRepository.getCategories(studyGroup.categories)
                 .onSuccess { categories ->
@@ -182,23 +169,25 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun removeUserFromStudyGroup(userId: String, studyGroupId: String) {
-        viewModelScope.launch {
-            userRepository.deleteStudyGroupUser(userId, studyGroupId)
-                .onSuccess {
-                    studyGroupRepository.deleteUser(studyGroupId, userId)
-                        .onSuccess {
-                            loadCurrentUser()
-                        }
-                        .onFailure {
-                            Log.e("MainViewModel", "Failed to remove user from study group", it)
-                            _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
-                        }
-                }
-                .onFailure {
-                    Log.e("MainViewModel", "Failed to remove user from study group", it)
-                    _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
-                }
+    fun deleteUserFromStudyGroup(studyGroupId: String) {
+        uiState.value.currentUser?.let { user ->
+            viewModelScope.launch {
+                userRepository.deleteStudyGroupUser(user.id, studyGroupId)
+                    .onSuccess {
+                        studyGroupRepository.deleteUser(studyGroupId, user.id)
+                            .onSuccess {
+                                loadCurrentUser()
+                            }
+                            .onFailure {
+                                Log.e("MainViewModel", "Failed to remove user from study group", it)
+                                _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                            }
+                    }
+                    .onFailure {
+                        Log.e("MainViewModel", "Failed to remove user from study group", it)
+                        _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                    }
+            }
         }
     }
 

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
@@ -93,8 +93,54 @@ class MainViewModel @Inject constructor(
 
     }
 
-    fun leaveStudyGroup(studyGroupId: String) {
+    fun leaveStudyGroup(studyGroup: StudyGroup) {
+        /*
+        if(그룹장)
+        1. 그룹 정보 가져오기
+        2. 각 카테고리 정보 가져오기
+        3. 각 카테고리의 각 퀴즈 정보 가져오기
+        3. 각 퀴즈의 각 문제 가져와서 지우기
+        4. 각 퀴즈의 각 userOmr 가져와서 지우기
+        5. 각 퀴즈 지우기
+        6. 각 카테고리 지우기
+        7. 각 그룹원 돌면서 그룹 지우기
+        8. 그룹 지우기
 
+        else
+        1. 유저 정보에서 그룹 지우기
+        2. 그룹에서 유저 지우기
+         */
+
+        uiState.value.currentUser?.let { user ->
+            when (studyGroup.id == user.id) {
+                true -> removeStudyGroup()
+                false -> removeUserFromStudyGroup(user.id, studyGroup.id)
+            }
+        }
+    }
+
+    private fun removeStudyGroup() {
+
+    }
+
+    private fun removeUserFromStudyGroup(userId: String, studyGroupId: String) {
+        viewModelScope.launch {
+            userRepository.deleteStudyGroupUser(userId, studyGroupId)
+                .onSuccess {
+                    studyGroupRepository.deleteUser(studyGroupId, userId)
+                        .onSuccess {
+                            loadCurrentUser()
+                        }
+                        .onFailure {
+                            Log.e("MainViewModel", "Failed to remove user from study group", it)
+                            _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                        }
+                }
+                .onFailure {
+                    Log.e("MainViewModel", "Failed to remove user from study group", it)
+                    _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                }
+        }
     }
 
     fun shownErrorMessage() {

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
@@ -63,7 +63,12 @@ class MainViewModel @Inject constructor(
                         }
                         .onFailure {
                             Log.e("MainViewModel", "Failed to load user", it)
-                            _uiState.update { it.copy(isLoading = false, errorMessage = "유저 로드에 실패했습니다.") }
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                    errorMessage = "유저 로드에 실패했습니다.",
+                                )
+                            }
                         }
                 }
                 .onFailure {
@@ -113,74 +118,148 @@ class MainViewModel @Inject constructor(
                                         .onSuccess {
                                             quizRepository.deleteQuizzes(quizzes.map { it.id })
                                                 .onSuccess {
-                                                    storageRepository.deleteImages(categories.map { it.categoryImageUrl }.filterNotNull())
+                                                    storageRepository.deleteImages(
+                                                        categories.map { it.categoryImageUrl }
+                                                            .filterNotNull(),
+                                                    )
                                                         .onSuccess {
-                                                            categoryRepository.deleteCategories(categories.map { it.id })
+                                                            categoryRepository.deleteCategories(
+                                                                categories.map { it.id },
+                                                            )
                                                                 .onSuccess {
-                                                                    notificationRepository.deleteNotification(notificationId = studyGroup.id)
+                                                                    notificationRepository.deleteNotification(
+                                                                        notificationId = studyGroup.id,
+                                                                    )
                                                                         .onSuccess {
-                                                                            storageRepository.deleteImages(studyGroup.studyGroupImageUrl?.let { listOf(it) } ?: emptyList())
+                                                                            storageRepository.deleteImages(
+                                                                                studyGroup.studyGroupImageUrl?.let {
+                                                                                    listOf(it)
+                                                                                } ?: emptyList(),
+                                                                            )
                                                                                 .onSuccess {
-                                                                                    userRepository.deleteStudyGroupUsers(studyGroup.users, studyGroup.id)
+                                                                                    userRepository.deleteStudyGroupUsers(
+                                                                                        studyGroup.users,
+                                                                                        studyGroup.id,
+                                                                                    )
                                                                                         .onSuccess {
-                                                                                            studyGroupRepository.deleteStudyGroup(studyGroup.id)
+                                                                                            studyGroupRepository.deleteStudyGroup(
+                                                                                                studyGroup.id,
+                                                                                            )
                                                                                                 .onSuccess {
-                                                                                                    Log.d("MainViewModel", "스터디 그룹 삭제 완료")
+                                                                                                    Log.d(
+                                                                                                        "MainViewModel",
+                                                                                                        "스터디 그룹 삭제 완료",
+                                                                                                    )
                                                                                                     loadCurrentUser() // 스터디 그룹 최신화
                                                                                                 }
                                                                                                 .onFailure {
-                                                                                                    Log.e("MainViewModel", "Failed to remove study group", it)
-                                                                                                    _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                                                                                                    Log.e(
+                                                                                                        "MainViewModel",
+                                                                                                        "Failed to remove study group",
+                                                                                                        it,
+                                                                                                    )
+                                                                                                    _uiState.update {
+                                                                                                        it.copy(
+                                                                                                            errorMessage = "스터디 그룹에서 나가지 못했습니다.",
+                                                                                                        )
+                                                                                                    }
                                                                                                 }
                                                                                         }
                                                                                         .onFailure {
-                                                                                            Log.e("MainViewModel", "Failed to remove users from study group", it)
-                                                                                            _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                                                                                            Log.e(
+                                                                                                "MainViewModel",
+                                                                                                "Failed to remove users from study group",
+                                                                                                it,
+                                                                                            )
+                                                                                            _uiState.update {
+                                                                                                it.copy(
+                                                                                                    errorMessage = "스터디 그룹에서 나가지 못했습니다.",
+                                                                                                )
+                                                                                            }
                                                                                         }
                                                                                 }
                                                                                 .onFailure {
-                                                                                    Log.e("MainViewModel", "Failed to remove study group image", it)
-                                                                                    _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                                                                                    Log.e(
+                                                                                        "MainViewModel",
+                                                                                        "Failed to remove study group image",
+                                                                                        it,
+                                                                                    )
+                                                                                    _uiState.update {
+                                                                                        it.copy(
+                                                                                            errorMessage = "스터디 그룹에서 나가지 못했습니다.",
+                                                                                        )
+                                                                                    }
                                                                                 }
                                                                         }
                                                                         .onFailure {
-                                                                            Log.e("MainViewModel", "Failed to remove notification", it)
-                                                                            _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                                                                            Log.e(
+                                                                                "MainViewModel",
+                                                                                "Failed to remove notification",
+                                                                                it,
+                                                                            )
+                                                                            _uiState.update {
+                                                                                it.copy(
+                                                                                    errorMessage = "스터디 그룹에서 나가지 못했습니다.",
+                                                                                )
+                                                                            }
                                                                         }
                                                                 }
                                                                 .onFailure {
-                                                                    Log.e("MainViewModel", "Failed to remove categories from study group", it)
-                                                                    _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
+                                                                    Log.e(
+                                                                        "MainViewModel",
+                                                                        "Failed to remove categories from study group",
+                                                                        it,
+                                                                    )
+                                                                    _uiState.update {
+                                                                        it.copy(
+                                                                            errorMessage = "스터디 그룹에서 나가지 못했습니다.",
+                                                                        )
+                                                                    }
                                                                 }
                                                         }
                                                         .onFailure {
-                                                            Log.e("MainViewModel", "Failed to remove categories images from study group", it)
+                                                            Log.e(
+                                                                "MainViewModel",
+                                                                "Failed to remove categories images from study group",
+                                                                it,
+                                                            )
                                                             _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
                                                         }
-                                                        .onFailure {
-                                                            Log.e("MainViewModel", "Failed to remove quizzes from study group", it)
-                                                            _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
-                                                        }
-                                                }
-                                                .onFailure {
-                                                    Log.e("MainViewModel", "Failed to remove userOmr from study group", it)
+                                                }.onFailure {
+                                                    Log.e(
+                                                        "MainViewModel",
+                                                        "Failed to remove quizzes from study group",
+                                                        it,
+                                                    )
                                                     _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
                                                 }
                                         }
                                         .onFailure {
-                                            Log.e("MainViewModel", "Failed to remove questions from study group", it)
+                                            Log.e(
+                                                "MainViewModel",
+                                                "Failed to remove userOmr from study group",
+                                                it,
+                                            )
                                             _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
                                         }
                                 }
                                 .onFailure {
-                                    Log.e("MainViewModel", "Failed to remove quizzes from study group", it)
+                                    Log.e(
+                                        "MainViewModel",
+                                        "Failed to remove questions from study group",
+                                        it,
+                                    )
                                     _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
                                 }
                         }
                         .onFailure {
-                            Log.e("MainViewModel", "Failed to remove categories from study group", it)
+                            Log.e("MainViewModel", "Failed to remove quizzes from study group", it)
                             _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
                         }
+                }
+                .onFailure {
+                    Log.e("MainViewModel", "Failed to remove categories from study group", it)
+                    _uiState.update { it.copy(errorMessage = "스터디 그룹에서 나가지 못했습니다.") }
                 }
         }
     }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/MainViewModel.kt
@@ -89,6 +89,14 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun editStudyGroup(studyGroupId: String) {
+
+    }
+
+    fun leaveStudyGroup(studyGroupId: String) {
+
+    }
+
     fun shownErrorMessage() {
         _uiState.update { it.copy(errorMessage = null) }
     }

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="des_btn_study_menu">스터디 메뉴</string>
     <string name="txt_study_user_count">인원: %1$s명</string>
     <string name="txt_study_group_menu_edit">수정</string>
+    <string name="txt_study_group_menu_delete">스터디 제거</string>
     <string name="txt_study_group_menu_leave">나가기</string>
     <string-array name="main_tabs_titles">
         <item>참여 스터디</item>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="des_img_study_image">스터디 이미지</string>
     <string name="des_btn_study_menu">스터디 메뉴</string>
     <string name="txt_study_user_count">인원: %1$s명</string>
+    <string name="txt_study_group_menu_edit">수정</string>
+    <string name="txt_study_group_menu_leave">나가기</string>
     <string-array name="main_tabs_titles">
         <item>참여 스터디</item>
         <item>보관함</item>

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
@@ -1,8 +1,10 @@
 package kr.boostcamp_2024.course.study
 
 import android.util.Log
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -14,6 +16,7 @@ import kr.boostcamp_2024.course.domain.model.StudyGroupCreationInfo
 import kr.boostcamp_2024.course.domain.repository.AuthRepository
 import kr.boostcamp_2024.course.domain.repository.StudyGroupRepository
 import kr.boostcamp_2024.course.domain.repository.UserRepository
+import kr.boostcamp_2024.course.study.navigation.CreateStudyRoute
 import javax.inject.Inject
 
 data class CreateStudyUiState(
@@ -33,11 +36,18 @@ class CreateStudyViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val studyGroupRepository: StudyGroupRepository,
     private val userRepository: UserRepository,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
+    private val studyGroupId: String? = savedStateHandle.toRoute<CreateStudyRoute>().studyGroupId
+
     private val _uiState = MutableStateFlow(CreateStudyUiState())
     val uiState = _uiState.onStart {
         loadCurrentUserId()
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), CreateStudyUiState())
+
+    init {
+        Log.d("studyGroupId", "$studyGroupId")
+    }
 
     fun loadCurrentUserId() {
         viewModelScope.launch {

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
@@ -63,7 +63,7 @@ class CreateStudyViewModel @Inject constructor(
 
                 _uiState.update { it.copy(isLoading = false, currentUserId = currentUser) }
             }.onFailure {
-                Log.e("MainViewModel", "Failed to load current user", it)
+                Log.e("CreateStudyViewModel", "Failed to load current user", it)
                 _uiState.update { it.copy(isLoading = false, snackBarMessage = "로그인한 유저가 없습니다.") }
             }
 
@@ -88,8 +88,13 @@ class CreateStudyViewModel @Inject constructor(
                             )
                         }
                     }.onFailure {
-                        Log.e("MainViewModel", "Failed to load study group", it)
-                        _uiState.update { it.copy(isLoading = false, snackBarMessage = "스터디 그룹 로드 실패") }
+                        Log.e("CreateStudyViewModel", "Failed to load study group", it)
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                snackBarMessage = "스터디 그룹 로드 실패",
+                            )
+                        }
                     }
             }
         }
@@ -125,16 +130,12 @@ class CreateStudyViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true) }
 
             studyGroupId?.let {
-                Log.d("MainViewModel", "${uiState.value.currentImage}")
-
                 val downloadUrl = uiState.value.currentImage?.let { imageByteArray ->
                     uiState.value.defaultImageUri?.let { defaultUri ->
                         storageRepository.deleteImage(defaultUri)
                     }
                     storageRepository.uploadImage(imageByteArray).getOrNull()
                 } ?: uiState.value.defaultImageUri
-
-                Log.d("MainViewModel", "$downloadUrl")
 
                 val studyGroupUpdatedInfo = StudyGroupUpdatedInfo(
                     studyGroupImageUrl = downloadUrl,
@@ -150,7 +151,12 @@ class CreateStudyViewModel @Inject constructor(
                     }
                     .onFailure {
                         Log.e("MainViewModel", "Failed to update study group", it)
-                        _uiState.update { it.copy(isLoading = true, snackBarMessage = "스터디 그룹 업데이트 실패") }
+                        _uiState.update {
+                            it.copy(
+                                isLoading = true,
+                                snackBarMessage = "스터디 그룹 업데이트 실패",
+                            )
+                        }
                     }
             }
         }
@@ -163,7 +169,7 @@ class CreateStudyViewModel @Inject constructor(
                 addStudyGroupToUser(currentUserId, studyId)
 
             }.onFailure { throwable ->
-                Log.d("errorMessage", "${throwable.message}")
+                Log.e("errorMessage", "${throwable.message}")
                 _uiState.update { it.copy(isLoading = false, snackBarMessage = "스터디 그룹 생성 실패") }
             }
         }
@@ -175,7 +181,7 @@ class CreateStudyViewModel @Inject constructor(
                 Log.d("addStudyGroupToUserResult", "성공, $result)")
                 _uiState.update { it.copy(isLoading = false, isSubmitStudySuccess = true) }
             }.onFailure { throwable ->
-                Log.d("addStudyGroupToUserResult", "실패, ${throwable.message})")
+                Log.e("addStudyGroupToUserResult", "실패, ${throwable.message})")
                 _uiState.update { it.copy(isLoading = false, snackBarMessage = "스터디 그룹 생성 실패") }
             }
         }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
@@ -22,6 +22,7 @@ import javax.inject.Inject
 
 data class CreateStudyUiState(
     val isEditMode: Boolean = false,
+    val imageUri: String? = null,
     val name: String = "",
     val description: String = "",
     val maxUserNum: String = "",
@@ -156,6 +157,10 @@ class CreateStudyViewModel @Inject constructor(
 
     fun onMaxUserNumChange(groupMemberNumber: String) {
         _uiState.update { it.copy(maxUserNum = groupMemberNumber) }
+    }
+
+    fun onImageUriChanged(imageUri: String) {
+        _uiState.update { it.copy(imageUri = imageUri) }
     }
 
     fun onSnackBarShown() {

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/component/CreateStudyTopAppBar.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/component/CreateStudyTopAppBar.kt
@@ -15,12 +15,16 @@ import kr.boostcamp_2024.course.study.R
 @ExperimentalMaterial3Api
 @Composable
 fun CreateStudyTopAppBar(
+    isEditMode: Boolean,
     onNavigationButtonClick: () -> Unit,
 ) {
     CenterAlignedTopAppBar(
         title = {
             Text(
-                text = stringResource(R.string.txt_create_study_top_app_bar),
+                text = when (isEditMode) {
+                    true -> stringResource(R.string.txt_edit_study_top_app_bar)
+                    false -> stringResource(R.string.txt_create_study_top_app_bar)
+                },
                 style = MaterialTheme.typography.titleLarge,
             )
         },

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/component/StudyCreationButton.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/component/StudyCreationButton.kt
@@ -13,20 +13,28 @@ import androidx.compose.ui.unit.dp
 import kr.boostcamp_2024.course.study.R
 
 @Composable
-fun StudyCreationButton(
-    onStudyCreationButtonClick: () -> Unit,
-    isCreateStudyButtonEnabled: Boolean,
+fun StudySubmitButton(
+    isEditMode: Boolean,
+    onStudyEditButtonClick: () -> Unit,
+    onStudyCreateButtonClick: () -> Unit,
+    canSubmitStudy: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Button(
-        onClick = onStudyCreationButtonClick,
+        onClick = when (isEditMode) {
+            true -> onStudyEditButtonClick
+            false -> onStudyCreateButtonClick
+        },
         modifier = modifier
             .fillMaxWidth()
             .padding(16.dp),
-        enabled = isCreateStudyButtonEnabled,
+        enabled = canSubmitStudy,
     ) {
         Text(
-            text = stringResource(R.string.txt_study_creation_button),
+            text = when (isEditMode) {
+                true -> stringResource(R.string.txt_study_edition_button)
+                false -> stringResource(R.string.txt_study_creation_button)
+            },
             modifier = modifier,
             style = MaterialTheme.typography.bodyMedium.copy(
                 fontWeight = FontWeight.Medium,

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/component/StudyCreationButton.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/component/StudyCreationButton.kt
@@ -1,7 +1,6 @@
 package kr.boostcamp_2024.course.study.component
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -9,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import kr.boostcamp_2024.course.study.R
 
 @Composable
@@ -25,9 +23,7 @@ fun StudySubmitButton(
             true -> onStudyEditButtonClick
             false -> onStudyCreateButtonClick
         },
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier = modifier.fillMaxWidth(),
         enabled = canSubmitStudy,
     ) {
         Text(

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
@@ -8,15 +8,17 @@ import kr.boostcamp_2024.course.study.presentation.CreateStudyScreen
 import kr.boostcamp_2024.course.study.presentation.DetailStudyScreen
 
 @Serializable
-data object CreateStudyRoute
+data class CreateStudyRoute(
+    val studyGroupId: String? = null,
+)
 
 @Serializable
 data class StudyRoute(
     val studyGroupId: String,
 )
 
-fun NavController.navigateCreateStudy() {
-    navigate(CreateStudyRoute)
+fun NavController.navigateCreateStudy(studyGroupId: String? = null) {
+    navigate(CreateStudyRoute(studyGroupId))
 }
 
 fun NavController.navigateStudy(studyGroupId: String) {

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
@@ -32,6 +32,7 @@ fun NavGraphBuilder.studyNavGraph(
     onCreateCategoryButtonClick: (String) -> Unit,
     onDeleteStudyGroupSuccess: () -> Unit,
     onLeaveStudyGroupSuccess: () -> Unit,
+    onEditStudyGroupButtonClick: (String) -> Unit,
 ) {
     composable<CreateStudyRoute> {
         CreateStudyScreen(
@@ -44,8 +45,9 @@ fun NavGraphBuilder.studyNavGraph(
         DetailStudyScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateCategoryButtonClick = onCreateCategoryButtonClick,
+            onEditStudyGroupButtonClick = onEditStudyGroupButtonClick,
             onCategoryClick = onCategoryClick,
-            onDetailStudyGroupSuccess = onDeleteStudyGroupSuccess,
+            onDeleteStudyGroupSuccess = onDeleteStudyGroupSuccess,
             onLeaveStudyGroupSuccess = onLeaveStudyGroupSuccess,
         )
     }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
@@ -29,6 +29,7 @@ fun NavGraphBuilder.studyNavGraph(
     onCategoryClick: (String) -> Unit,
     onCreateCategoryButtonClick: (String) -> Unit,
     onDeleteStudyGroupSuccess: () -> Unit,
+    onLeaveStudyGroupSuccess: () -> Unit,
 ) {
     composable<CreateStudyRoute> {
         CreateStudyScreen(
@@ -43,6 +44,7 @@ fun NavGraphBuilder.studyNavGraph(
             onCreateCategoryButtonClick = onCreateCategoryButtonClick,
             onCategoryClick = onCategoryClick,
             onDetailStudyGroupSuccess = onDeleteStudyGroupSuccess,
+            onLeaveStudyGroupSuccess = onLeaveStudyGroupSuccess,
         )
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
@@ -27,7 +27,7 @@ fun NavController.navigateStudy(studyGroupId: String) {
 
 fun NavGraphBuilder.studyNavGraph(
     onNavigationButtonClick: () -> Unit,
-    onCreateStudySuccess: () -> Unit,
+    onSubmitStudySuccess: () -> Unit,
     onCategoryClick: (String) -> Unit,
     onCreateCategoryButtonClick: (String) -> Unit,
     onDeleteStudyGroupSuccess: () -> Unit,
@@ -37,7 +37,7 @@ fun NavGraphBuilder.studyNavGraph(
     composable<CreateStudyRoute> {
         CreateStudyScreen(
             onNavigationButtonClick = onNavigationButtonClick,
-            onCreateStudySuccess = onCreateStudySuccess,
+            onSubmitStudySuccess = onSubmitStudySuccess,
         )
     }
 

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
@@ -28,6 +28,7 @@ fun NavGraphBuilder.studyNavGraph(
     onCreateStudySuccess: () -> Unit,
     onCategoryClick: (String) -> Unit,
     onCreateCategoryButtonClick: (String) -> Unit,
+    onDeleteStudyGroupSuccess: () -> Unit,
 ) {
     composable<CreateStudyRoute> {
         CreateStudyScreen(
@@ -41,6 +42,7 @@ fun NavGraphBuilder.studyNavGraph(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateCategoryButtonClick = onCreateCategoryButtonClick,
             onCategoryClick = onCategoryClick,
+            onDetailStudyGroupSuccess = onDeleteStudyGroupSuccess,
         )
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
@@ -45,8 +44,6 @@ import kr.boostcamp_2024.course.study.R
 import kr.boostcamp_2024.course.study.component.CreateStudyTopAppBar
 import kr.boostcamp_2024.course.study.component.StudySubmitButton
 import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.FileOutputStream
 
 @Composable
 fun CreateStudyScreen(
@@ -59,7 +56,8 @@ fun CreateStudyScreen(
 
     CreateStudyScreen(
         isEditMode = uiState.isEditMode,
-        studyImageUri = uiState.imageUri,
+        defaultStudyImageUri = uiState.defaultImageUri,
+        currentStudyImage = uiState.currentImage,
         titleText = uiState.name,
         descriptionText = uiState.description,
         groupMemberNumber = uiState.maxUserNum,
@@ -71,7 +69,7 @@ fun CreateStudyScreen(
         onMaxUserNumChange = viewmodel::onMaxUserNumChange,
         onStudyEditButtonClick = viewmodel::updateStudyGroup,
         onCreationButtonClick = viewmodel::createStudyGroupClick,
-        onStudyImgUriChanged = viewmodel::onImageUriChanged,
+        onCurrentStudyImageChanged = viewmodel::onImageByteArrayChanged,
     )
 
     if (uiState.isSubmitStudySuccess) {
@@ -92,7 +90,8 @@ fun CreateStudyScreen(
 @Composable
 fun CreateStudyScreen(
     isEditMode: Boolean,
-    studyImageUri: String?,
+    defaultStudyImageUri: String?,
+    currentStudyImage: ByteArray?,
     titleText: String,
     descriptionText: String,
     groupMemberNumber: String,
@@ -104,7 +103,7 @@ fun CreateStudyScreen(
     onMaxUserNumChange: (String) -> Unit,
     onStudyEditButtonClick: () -> Unit,
     onCreationButtonClick: () -> Unit,
-    onStudyImgUriChanged: (String) -> Unit,
+    onCurrentStudyImageChanged: (ByteArray) -> Unit,
 ) {
     val context = LocalContext.current
     val scrollState = rememberScrollState()
@@ -115,13 +114,9 @@ fun CreateStudyScreen(
 
             val baos = ByteArrayOutputStream()
             bitmap.compress(Bitmap.CompressFormat.JPEG, 50, baos)
+            val data = baos.toByteArray()
 
-            val tempFile = File.createTempFile("resized_image", ".jpg", context.cacheDir)
-            val fileOutputStream = FileOutputStream(tempFile)
-            fileOutputStream.write(baos.toByteArray())
-            fileOutputStream.close()
-
-            onStudyImgUriChanged(tempFile.toUri().toString())
+            onCurrentStudyImageChanged(data)
         }
     }
 
@@ -149,7 +144,7 @@ fun CreateStudyScreen(
                     .clickable(enabled = true) {
                         photoPickerLauncher.launch(PickVisualMediaRequest(ImageOnly))
                     },
-                imgUrl = studyImageUri,
+                imgUrl = currentStudyImage ?: defaultStudyImageUri,
                 contentDescription = "스터디 배경 이미지",
                 placeholder = painterResource(R.drawable.img_photo_picker),
                 error = painterResource(R.drawable.img_photo_picker),
@@ -209,7 +204,8 @@ fun CreateStudyScreenPreview() {
     WeQuizTheme {
         CreateStudyScreen(
             isEditMode = false,
-            studyImageUri = null,
+            defaultStudyImageUri = null,
+            currentStudyImage = null,
             titleText = "",
             descriptionText = "",
             groupMemberNumber = "",
@@ -221,7 +217,7 @@ fun CreateStudyScreenPreview() {
             onMaxUserNumChange = {},
             onStudyEditButtonClick = {},
             onCreationButtonClick = {},
-            onStudyImgUriChanged = {},
+            onCurrentStudyImageChanged = {},
         )
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +40,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizAsyncImage
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizTextField
@@ -121,16 +123,19 @@ fun CreateStudyScreen(
 ) {
     val context = LocalContext.current
     val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
     val photoPickerLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
         if (uri != null) {
-            val inputStream = context.contentResolver.openInputStream(uri)
-            val bitmap = BitmapFactory.decodeStream(inputStream)
+            coroutineScope.launch {
+                val inputStream = context.contentResolver.openInputStream(uri)
+                val bitmap = BitmapFactory.decodeStream(inputStream)
 
-            val baos = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 50, baos)
-            val data = baos.toByteArray()
+                val baos = ByteArrayOutputStream()
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 50, baos)
+                val data = baos.toByteArray()
 
-            onCurrentStudyImageChanged(data)
+                onCurrentStudyImageChanged(data)
+            }
         }
     }
 

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -9,15 +9,15 @@ import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -133,14 +133,16 @@ fun CreateStudyScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .padding(horizontal = 16.dp)
                 .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             WeQuizAsyncImage(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(148.dp)
-                    .padding(vertical = 10.dp, horizontal = 16.dp)
-                    .clip(shape = RoundedCornerShape(18.dp))
+                    .padding(horizontal = 70.dp)
+                    .aspectRatio(1f)
+                    .clip(shape = MaterialTheme.shapes.large)
                     .clickable(enabled = true) {
                         photoPickerLauncher.launch(PickVisualMediaRequest(ImageOnly))
                     },
@@ -151,36 +153,31 @@ fun CreateStudyScreen(
                 fallback = painterResource(R.drawable.img_photo_picker),
             )
 
-            Column(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                WeQuizTextField(
-                    label = stringResource(R.string.txt_create_study_title_text_field_label),
-                    text = titleText,
-                    onTextChanged = onTitleTextChange,
-                    placeholder = stringResource(R.string.txt_create_study_title_text_field_placeholder),
-                )
+            WeQuizTextField(
+                label = stringResource(R.string.txt_create_study_title_text_field_label),
+                text = titleText,
+                onTextChanged = onTitleTextChange,
+                placeholder = stringResource(R.string.txt_create_study_title_text_field_placeholder),
+            )
 
-                WeQuizTextField(
-                    label = stringResource(R.string.txt_create_study_description_label),
-                    text = descriptionText,
-                    minLines = 6,
-                    maxLines = 6,
-                    onTextChanged = onDescriptionTextChange,
-                    placeholder = stringResource(R.string.txt_create_study_description_placeholder),
-                )
+            WeQuizTextField(
+                label = stringResource(R.string.txt_create_study_description_label),
+                text = descriptionText,
+                minLines = 6,
+                maxLines = 6,
+                onTextChanged = onDescriptionTextChange,
+                placeholder = stringResource(R.string.txt_create_study_description_placeholder),
+            )
 
-                WeQuizValidateTextField(
-                    label = stringResource(R.string.txt_create_study_group_member_number_label),
-                    text = groupMemberNumber,
-                    onTextChanged = onMaxUserNumChange,
-                    placeholder = stringResource(R.string.txt_create_study_group_member_number_placeholder),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                    validFun = ::isValidateNumber,
-                    errorMessage = stringResource(R.string.txt_create_study_group_number_error_message),
-                )
-            }
+            WeQuizValidateTextField(
+                label = stringResource(R.string.txt_create_study_group_member_number_label),
+                text = groupMemberNumber,
+                onTextChanged = onMaxUserNumChange,
+                placeholder = stringResource(R.string.txt_create_study_group_member_number_placeholder),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                validFun = ::isValidateNumber,
+                errorMessage = stringResource(R.string.txt_create_study_group_number_error_message),
+            )
 
             StudySubmitButton(
                 isEditMode = isEditMode,

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -166,7 +166,7 @@ fun CreateStudyScreen(
                         photoPickerLauncher.launch(PickVisualMediaRequest(ImageOnly))
                     },
                 imgUrl = currentStudyImage ?: defaultStudyImageUri,
-                contentDescription = "스터디 배경 이미지",
+                contentDescription = stringResource(R.string.des_study_group_image),
                 placeholder = painterResource(R.drawable.img_photo_picker),
                 error = painterResource(R.drawable.img_photo_picker),
                 fallback = painterResource(R.drawable.img_photo_picker),

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -8,14 +8,17 @@ import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -25,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -71,6 +75,16 @@ fun CreateStudyScreen(
         onCreationButtonClick = viewmodel::createStudyGroupClick,
         onCurrentStudyImageChanged = viewmodel::onImageByteArrayChanged,
     )
+
+    if (uiState.isLoading) {
+        Box {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(64.dp)
+                    .align(Alignment.Center),
+            )
+        }
+    }
 
     if (uiState.isSubmitStudySuccess) {
         LaunchedEffect(Unit) {

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -39,7 +39,7 @@ import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizValidateTe
 import kr.boostcamp_2024.course.study.CreateStudyViewModel
 import kr.boostcamp_2024.course.study.R
 import kr.boostcamp_2024.course.study.component.CreateStudyTopAppBar
-import kr.boostcamp_2024.course.study.component.StudyCreationButton
+import kr.boostcamp_2024.course.study.component.StudySubmitButton
 
 @Composable
 fun CreateStudyScreen(
@@ -50,11 +50,12 @@ fun CreateStudyScreen(
     val uiState by viewmodel.uiState.collectAsStateWithLifecycle()
 
     CreateStudyScreen(
+        isEditMode = uiState.isEditMode,
         titleText = uiState.name,
         onTitleTextChange = viewmodel::onNameChanged,
         descriptionText = uiState.description,
         onDescriptionTextChange = viewmodel::onDescriptionChanged,
-        groupMemberNumber = uiState.groupMemberNumber,
+        groupMemberNumber = uiState.maxUserNum,
         onGroupMemberNumberChange = viewmodel::onGroupMemberNumberChanged,
         onCreationButtonClick = viewmodel::createStudyGroupClick,
         snackBarMessage = uiState.snackBarMessage,
@@ -62,7 +63,7 @@ fun CreateStudyScreen(
         onSnackBarShown = viewmodel::onSnackBarShown,
         isCreateStudySuccess = uiState.isCreateStudySuccess,
         onCreateStudySuccess = onCreateStudySuccess,
-        isCreateStudyButtonEnabled = uiState.isCreateStudyButtonEnabled,
+        canSubmitStudy = uiState.canSubmitStudy,
         onStudyImgUriChanged = { },
     )
 }
@@ -70,6 +71,7 @@ fun CreateStudyScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateStudyScreen(
+    isEditMode: Boolean,
     onNavigationButtonClick: () -> Unit,
     titleText: String,
     onTitleTextChange: (String) -> Unit,
@@ -82,7 +84,7 @@ fun CreateStudyScreen(
     onSnackBarShown: () -> Unit,
     isCreateStudySuccess: Boolean,
     onCreateStudySuccess: () -> Unit,
-    isCreateStudyButtonEnabled: Boolean,
+    canSubmitStudy: Boolean,
     onStudyImgUriChanged: (String) -> Unit,
 ) {
 
@@ -101,7 +103,10 @@ fun CreateStudyScreen(
     Scaffold(
         snackbarHost = { SnackbarHost(snackBarHostState) },
         topBar = {
-            CreateStudyTopAppBar(onNavigationButtonClick = onNavigationButtonClick)
+            CreateStudyTopAppBar(
+                isEditMode = isEditMode,
+                onNavigationButtonClick = onNavigationButtonClick,
+            )
         },
     ) { paddingValues ->
         Column(
@@ -155,10 +160,13 @@ fun CreateStudyScreen(
                 )
             }
 
-            StudyCreationButton(
-                onStudyCreationButtonClick = onCreationButtonClick,
-                isCreateStudyButtonEnabled = isCreateStudyButtonEnabled,
+            StudySubmitButton(
+                isEditMode = isEditMode,
+                onStudyEditButtonClick = onCreationButtonClick,
+                onStudyCreateButtonClick = onCreationButtonClick,
+                canSubmitStudy = canSubmitStudy,
             )
+
             snackBarMessage?.let { message ->
                 LaunchedEffect(message) {
                     snackBarHostState.showSnackbar(message)
@@ -192,8 +200,9 @@ fun CreateStudyScreenPreview() {
             onSnackBarShown = {},
             isCreateStudySuccess = false,
             onCreateStudySuccess = {},
-            isCreateStudyButtonEnabled = false,
+            canSubmitStudy = false,
             onStudyImgUriChanged = {},
+            isEditMode = false,
         )
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -44,51 +44,59 @@ import kr.boostcamp_2024.course.study.component.StudySubmitButton
 @Composable
 fun CreateStudyScreen(
     viewmodel: CreateStudyViewModel = hiltViewModel<CreateStudyViewModel>(),
+    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNavigationButtonClick: () -> Unit,
-    onCreateStudySuccess: () -> Unit,
+    onSubmitStudySuccess: () -> Unit,
 ) {
     val uiState by viewmodel.uiState.collectAsStateWithLifecycle()
 
     CreateStudyScreen(
         isEditMode = uiState.isEditMode,
         titleText = uiState.name,
-        onTitleTextChange = viewmodel::onNameChanged,
         descriptionText = uiState.description,
-        onDescriptionTextChange = viewmodel::onDescriptionChanged,
         groupMemberNumber = uiState.maxUserNum,
-        onGroupMemberNumberChange = viewmodel::onGroupMemberNumberChanged,
-        onCreationButtonClick = viewmodel::createStudyGroupClick,
-        snackBarMessage = uiState.snackBarMessage,
-        onNavigationButtonClick = onNavigationButtonClick,
-        onSnackBarShown = viewmodel::onSnackBarShown,
-        isCreateStudySuccess = uiState.isCreateStudySuccess,
-        onCreateStudySuccess = onCreateStudySuccess,
         canSubmitStudy = uiState.canSubmitStudy,
-        onStudyImgUriChanged = { },
+        snackBarHostState = snackBarHostState,
+        onNavigationButtonClick = onNavigationButtonClick,
+        onTitleTextChange = viewmodel::onNameChanged,
+        onDescriptionTextChange = viewmodel::onDescriptionChanged,
+        onMaxUserNumChange = viewmodel::onMaxUserNumChange,
+        onStudyEditButtonClick = viewmodel::updateStudyGroup,
+        onCreationButtonClick = viewmodel::createStudyGroupClick,
+        onStudyImgUriChanged = {},
     )
+
+    if (uiState.isSubmitStudySuccess) {
+        LaunchedEffect(Unit) {
+            onSubmitStudySuccess()
+        }
+    }
+
+    uiState.snackBarMessage?.let { message ->
+        LaunchedEffect(message) {
+            snackBarHostState.showSnackbar(message)
+            viewmodel.onSnackBarShown()
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateStudyScreen(
     isEditMode: Boolean,
-    onNavigationButtonClick: () -> Unit,
     titleText: String,
-    onTitleTextChange: (String) -> Unit,
     descriptionText: String,
-    onDescriptionTextChange: (String) -> Unit,
     groupMemberNumber: String,
-    onGroupMemberNumberChange: (String) -> Unit,
-    snackBarMessage: String?,
-    onCreationButtonClick: () -> Unit,
-    onSnackBarShown: () -> Unit,
-    isCreateStudySuccess: Boolean,
-    onCreateStudySuccess: () -> Unit,
     canSubmitStudy: Boolean,
+    snackBarHostState: SnackbarHostState,
+    onNavigationButtonClick: () -> Unit,
+    onTitleTextChange: (String) -> Unit,
+    onDescriptionTextChange: (String) -> Unit,
+    onMaxUserNumChange: (String) -> Unit,
+    onStudyEditButtonClick: () -> Unit,
+    onCreationButtonClick: () -> Unit,
     onStudyImgUriChanged: (String) -> Unit,
 ) {
-
-    val snackBarHostState = remember { SnackbarHostState() }
     val scrollState = rememberScrollState()
     val photoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
@@ -96,18 +104,14 @@ fun CreateStudyScreen(
         },
     )
 
-    if (isCreateStudySuccess) {
-        onCreateStudySuccess()
-    }
-
     Scaffold(
-        snackbarHost = { SnackbarHost(snackBarHostState) },
         topBar = {
             CreateStudyTopAppBar(
                 isEditMode = isEditMode,
                 onNavigationButtonClick = onNavigationButtonClick,
             )
         },
+        snackbarHost = { SnackbarHost(snackBarHostState) },
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -152,7 +156,7 @@ fun CreateStudyScreen(
                 WeQuizValidateTextField(
                     label = stringResource(R.string.txt_create_study_group_member_number_label),
                     text = groupMemberNumber,
-                    onTextChanged = onGroupMemberNumberChange,
+                    onTextChanged = onMaxUserNumChange,
                     placeholder = stringResource(R.string.txt_create_study_group_member_number_placeholder),
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                     validFun = ::isValidateNumber,
@@ -162,17 +166,10 @@ fun CreateStudyScreen(
 
             StudySubmitButton(
                 isEditMode = isEditMode,
-                onStudyEditButtonClick = onCreationButtonClick,
+                onStudyEditButtonClick = onStudyEditButtonClick,
                 onStudyCreateButtonClick = onCreationButtonClick,
                 canSubmitStudy = canSubmitStudy,
             )
-
-            snackBarMessage?.let { message ->
-                LaunchedEffect(message) {
-                    snackBarHostState.showSnackbar(message)
-                    onSnackBarShown()
-                }
-            }
         }
     }
 }
@@ -188,21 +185,19 @@ fun isValidateNumber(inputNumber: String): Boolean {
 fun CreateStudyScreenPreview() {
     WeQuizTheme {
         CreateStudyScreen(
-            onNavigationButtonClick = {},
-            titleText = "",
-            onTitleTextChange = {},
-            descriptionText = "",
-            onDescriptionTextChange = {},
-            groupMemberNumber = "",
-            onGroupMemberNumberChange = {},
-            snackBarMessage = "",
-            onCreationButtonClick = {},
-            onSnackBarShown = {},
-            isCreateStudySuccess = false,
-            onCreateStudySuccess = {},
-            canSubmitStudy = false,
-            onStudyImgUriChanged = {},
             isEditMode = false,
+            titleText = "",
+            descriptionText = "",
+            groupMemberNumber = "",
+            canSubmitStudy = false,
+            snackBarHostState = remember { SnackbarHostState() },
+            onNavigationButtonClick = {},
+            onTitleTextChange = {},
+            onDescriptionTextChange = {},
+            onMaxUserNumChange = {},
+            onStudyEditButtonClick = {},
+            onCreationButtonClick = {},
+            onStudyImgUriChanged = {},
         )
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
@@ -55,6 +55,7 @@ fun DetailStudyScreen(
     onCreateCategoryButtonClick: (String) -> Unit,
     onCategoryClick: (String) -> Unit,
     onDetailStudyGroupSuccess: () -> Unit,
+    onLeaveStudyGroupSuccess: () -> Unit,
     viewModel: DetailStudyViewModel = hiltViewModel(),
     snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
@@ -98,6 +99,12 @@ fun DetailStudyScreen(
     if (uiState.isDeleteStudyGroupSuccess) {
         LaunchedEffect(Unit) {
             onDetailStudyGroupSuccess()
+        }
+    }
+
+    if (uiState.isLeaveStudyGroupSuccess) {
+        LaunchedEffect(Unit) {
+            onLeaveStudyGroupSuccess()
         }
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
@@ -54,8 +54,9 @@ fun DetailStudyScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateCategoryButtonClick: (String) -> Unit,
     onCategoryClick: (String) -> Unit,
-    onDetailStudyGroupSuccess: () -> Unit,
+    onDeleteStudyGroupSuccess: () -> Unit,
     onLeaveStudyGroupSuccess: () -> Unit,
+    onEditStudyGroupButtonClick: (String) -> Unit,
     viewModel: DetailStudyViewModel = hiltViewModel(),
     snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
@@ -73,7 +74,7 @@ fun DetailStudyScreen(
         onCategoryClick = onCategoryClick,
         onRemoveStudyGroupMemberButtonClick = viewModel::deleteStudyGroupMember,
         onInviteConfirmButtonClick = viewModel::addNotification,
-        onEditStudyGroupClick = {},
+        onEditStudyGroupClick = onEditStudyGroupButtonClick,
         onDeleteStudyGroupClick = viewModel::deleteStudyGroup,
         onLeaveStudyGroupClick = viewModel::deleteUserFromStudyGroup,
     )
@@ -98,7 +99,7 @@ fun DetailStudyScreen(
 
     if (uiState.isDeleteStudyGroupSuccess) {
         LaunchedEffect(Unit) {
-            onDetailStudyGroupSuccess()
+            onDeleteStudyGroupSuccess()
         }
     }
 
@@ -123,7 +124,7 @@ fun DetailStudyScreen(
     onCategoryClick: (String) -> Unit,
     onRemoveStudyGroupMemberButtonClick: (String, String) -> Unit,
     onInviteConfirmButtonClick: (String, String) -> Unit,
-    onEditStudyGroupClick: () -> Unit,
+    onEditStudyGroupClick: (String) -> Unit,
     onDeleteStudyGroupClick: () -> Unit,
     onLeaveStudyGroupClick: () -> Unit,
 ) {
@@ -160,7 +161,7 @@ fun DetailStudyScreen(
                     currentGroup?.let {
                         StudyDropDownMenu(
                             isOwner = (owner?.id == currentUserId),
-                            onEditStudyGroupClick = onEditStudyGroupClick,
+                            onEditStudyGroupClick = { onEditStudyGroupClick(currentGroup.id) },
                             onDeleteStudyGroupClick = onDeleteStudyGroupClick,
                             onLeaveStudyGroupClick = onLeaveStudyGroupClick,
                         )

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.study.presentation
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -8,7 +9,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -23,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -37,7 +42,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.coroutines.launch
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizImageLargeTopAppBar
 import kr.boostcamp_2024.course.domain.model.Category
 import kr.boostcamp_2024.course.domain.model.StudyGroup
@@ -90,6 +94,7 @@ fun DetailStudyScreen(
     onRemoveStudyGroupMemberButtonClick: (String, String) -> Unit,
     onInviteConfirmButtonClick: (String, String) -> Unit,
 ) {
+    var dropDownMenuExpanded by remember { mutableStateOf(false) }
     var selectedScreenIndex by remember { mutableIntStateOf(0) }
     val screenList = listOf(
         DetailScreenRoute,
@@ -125,14 +130,22 @@ fun DetailStudyScreen(
                     )
                 },
                 actions = {
-                    CustomIconButton(
-                        onClicked = {
-                            coroutineScope.launch {
-                                snackBarHostState.showSnackbar(context.getString(R.string.btn_setting_snack_bar_message))
-                            }
+                    StudyDropDownMenu(
+                        isOwner = (owner?.id == curUserId),
+                        dropDownMenuExpanded = dropDownMenuExpanded,
+                        onDismissRequest = { dropDownMenuExpanded = !dropDownMenuExpanded },
+                        onEditClick = {
+                            dropDownMenuExpanded = false
+                            Log.d("zzz", "스터디 수정")
                         },
-                        imageVector = Icons.Filled.Settings,
-                        description = stringResource(R.string.btn_top_bar_detail_study_setting),
+                        onDeleteClick = {
+                            dropDownMenuExpanded = false
+                            Log.d("zzz", "스터디 삭제")
+                        },
+                        onQuitClick = {
+                            dropDownMenuExpanded = false
+                            Log.d("zzz", "스터디 나가기")
+                        },
                     )
                 },
             )
@@ -203,6 +216,51 @@ fun DetailStudyScreen(
         LaunchedEffect(errorMessageId) {
             snackBarHostState.showSnackbar(context.getString(errorMessageId))
             onErrorMessageShown()
+        }
+    }
+}
+
+@Composable
+fun StudyDropDownMenu(
+    isOwner: Boolean,
+    dropDownMenuExpanded: Boolean,
+    onDismissRequest: () -> Unit,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onQuitClick: () -> Unit,
+) {
+    Box {
+        CustomIconButton(
+            onClicked = { onDismissRequest() },
+            imageVector = Icons.Filled.Settings,
+            description = stringResource(R.string.btn_top_bar_detail_study_setting),
+        )
+        DropdownMenu(expanded = dropDownMenuExpanded, onDismissRequest = { onDismissRequest() }) {
+            if (isOwner) {
+                DropdownMenuItem(
+                    text = { Text("수정") },
+                    onClick = {
+                        onDismissRequest()
+                        onEditClick()
+                    },
+                )
+                HorizontalDivider()
+                DropdownMenuItem(
+                    text = { Text("스터디 삭제") },
+                    onClick = {
+                        onDismissRequest()
+                        onDeleteClick()
+                    },
+                )
+            } else {
+                DropdownMenuItem(
+                    text = { Text("나가기") },
+                    onClick = {
+                        onDismissRequest()
+                        onQuitClick()
+                    },
+                )
+            }
         }
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/viewmodel/DetailStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/viewmodel/DetailStudyViewModel.kt
@@ -37,6 +37,7 @@ data class DetailStudyUiState(
     val owner: User? = null,
     val userId: String? = null,
     val isDeleteStudyGroupSuccess: Boolean = false,
+    val isLeaveStudyGroupSuccess: Boolean = false,
 )
 
 @HiltViewModel
@@ -336,7 +337,7 @@ class DetailStudyViewModel @Inject constructor(
                 .onSuccess {
                     studyGroupRepository.deleteUser(studyGroupId, userId)
                         .onSuccess {
-                            loadCurrentUser()
+                            _uiState.update { it.copy(isLeaveStudyGroupSuccess = true) }
                         }
                         .onFailure {
                             Log.e("MainViewModel", "Failed to remove user from study group", it)

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/viewmodel/DetailStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/viewmodel/DetailStudyViewModel.kt
@@ -19,7 +19,10 @@ import kr.boostcamp_2024.course.domain.model.User
 import kr.boostcamp_2024.course.domain.repository.AuthRepository
 import kr.boostcamp_2024.course.domain.repository.CategoryRepository
 import kr.boostcamp_2024.course.domain.repository.NotificationRepository
+import kr.boostcamp_2024.course.domain.repository.QuestionRepository
+import kr.boostcamp_2024.course.domain.repository.QuizRepository
 import kr.boostcamp_2024.course.domain.repository.StudyGroupRepository
+import kr.boostcamp_2024.course.domain.repository.UserOmrRepository
 import kr.boostcamp_2024.course.domain.repository.UserRepository
 import kr.boostcamp_2024.course.study.R
 import kr.boostcamp_2024.course.study.navigation.StudyRoute
@@ -42,23 +45,31 @@ class DetailStudyViewModel @Inject constructor(
     private val categoryRepository: CategoryRepository,
     private val authRepository: AuthRepository,
     private val notificationRepository: NotificationRepository,
+    private val quizRepository: QuizRepository,
+    private val questionRepository: QuestionRepository,
+    private val userOmrRepository: UserOmrRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val studyGroupId: String = savedStateHandle.toRoute<StudyRoute>().studyGroupId
 
     private val _uiState: MutableStateFlow<DetailStudyUiState> = MutableStateFlow(DetailStudyUiState())
     val uiState: StateFlow<DetailStudyUiState> = _uiState.onStart {
-        val studyGroupId = savedStateHandle.toRoute<StudyRoute>().studyGroupId
-        authRepository.getUserKey().onSuccess { userKey ->
-            val userId = requireNotNull(userKey)
-            _uiState.update { it.copy(userId = userId) }
-        }.onFailure {
-            Log.e("DetailStudyViewModel", "Failed to get user key", it)
-        }
-        loadStudyGroup(studyGroupId)
+        loadCurrentUser()
+        loadStudyGroup()
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), DetailStudyUiState())
 
-    private fun loadStudyGroup(studyGroupId: String) {
+    private fun loadCurrentUser() {
+        viewModelScope.launch {
+            authRepository.getUserKey()
+                .onSuccess { userKey ->
+                    _uiState.update { it.copy(userId = userKey) }
+                }.onFailure {
+                    Log.e("DetailStudyViewModel", "Failed to get user key", it)
+                }
+        }
+    }
+
+    private fun loadStudyGroup() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             studyGroupRepository.getStudyGroup(studyGroupId)
@@ -84,154 +95,261 @@ class DetailStudyViewModel @Inject constructor(
 
     private fun getStudyGroup(studyGroupId: String) {
         viewModelScope.launch {
-            studyGroupRepository.getStudyGroup(studyGroupId).onSuccess { currentGroup ->
-                val ownerId = currentGroup.ownerId
-                val categoryIds = currentGroup.categories
-                val userIds = currentGroup.users
-                loadCategories(currentGroup, categoryIds)
-                loadUsers(currentGroup, userIds)
-                loadOwner(currentGroup, ownerId)
-            }.onFailure {
-                Log.e("DetailStudyViewModel", "Failed to load study group", it)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessageId = R.string.error_message_load_study_group,
-                    )
+            studyGroupRepository.getStudyGroup(studyGroupId)
+                .onSuccess { currentGroup ->
+                    val ownerId = currentGroup.ownerId
+                    val categoryIds = currentGroup.categories
+                    val userIds = currentGroup.users
+                    loadCategories(currentGroup, categoryIds)
+                    loadUsers(currentGroup, userIds)
+                    loadOwner(currentGroup, ownerId)
+                }.onFailure {
+                    Log.e("DetailStudyViewModel", "Failed to load study group", it)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessageId = R.string.error_message_load_study_group,
+                        )
+                    }
                 }
-            }
         }
     }
 
     private fun loadCategories(currentGroup: StudyGroup, categoryIds: List<String>) {
         viewModelScope.launch {
-            categoryRepository.getCategories(categoryIds).onSuccess { categories ->
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        currentGroup = currentGroup,
-                        categories = categories,
-                    )
+            categoryRepository.getCategories(categoryIds)
+                .onSuccess { categories ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            currentGroup = currentGroup,
+                            categories = categories,
+                        )
+                    }
+                }.onFailure { it ->
+                    Log.e("DetailStudyViewModel", "Failed to load categories", it)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessageId = R.string.error_message_load_categories,
+                        )
+                    }
                 }
-            }.onFailure { it ->
-                Log.e("DetailStudyViewModel", "Failed to load categories", it)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessageId = R.string.error_message_load_categories,
-                    )
-                }
-            }
         }
     }
 
     private fun loadUsers(currentGroup: StudyGroup, userIds: List<String>) {
         viewModelScope.launch {
-            userRepository.getUsers(userIds).onSuccess { users ->
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        currentGroup = currentGroup,
-                        users = users,
-                    )
+            userRepository.getUsers(userIds)
+                .onSuccess { users ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            currentGroup = currentGroup,
+                            users = users,
+                        )
+                    }
+                }.onFailure {
+                    Log.e("DetailStudyViewModel", "Failed to load users", it)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessageId = R.string.error_message_load_users,
+                        )
+                    }
                 }
-            }.onFailure {
-                Log.e("DetailStudyViewModel", "Failed to load users", it)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessageId = R.string.error_message_load_users,
-                    )
-                }
-            }
         }
     }
 
     private fun loadOwner(currentGroup: StudyGroup, ownerId: String) {
         viewModelScope.launch {
-            userRepository.getUser(ownerId).onSuccess { owner ->
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        currentGroup = currentGroup,
-                        owner = owner,
-                    )
+            userRepository.getUser(ownerId)
+                .onSuccess { owner ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            currentGroup = currentGroup,
+                            owner = owner,
+                        )
+                    }
+                }.onFailure {
+                    Log.e("DetailStudyViewModel", "Failed to load users", it)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessageId = R.string.error_message_load_owner,
+                        )
+                    }
                 }
-            }.onFailure {
-                Log.e("DetailStudyViewModel", "Failed to load users", it)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessageId = R.string.error_message_load_owner,
-                    )
-                }
-            }
         }
     }
 
     fun addNotification(groupId: String, email: String) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
-            userRepository.findUserByEmail(email).onSuccess {
-                notificationRepository.addNotification(groupId, it.id).onSuccess {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                        )
-                    }
+            userRepository.findUserByEmail(email)
+                .onSuccess {
+                    notificationRepository.addNotification(groupId, it.id)
+                        .onSuccess {
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                )
+                            }
+                        }.onFailure {
+                            Log.e("DetailStudyViewModel", "Failed to add notification", it)
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                    errorMessageId = R.string.error_message_add_notification,
+                                )
+                            }
+                        }
                 }.onFailure {
-                    Log.e("DetailStudyViewModel", "Failed to add notification", it)
+                    Log.e("DetailStudyViewModel", "Failed to find user", it)
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            errorMessageId = R.string.error_message_add_notification,
+                            errorMessageId = R.string.error_message_find_user,
                         )
                     }
                 }
-            }.onFailure {
-                Log.e("DetailStudyViewModel", "Failed to find user", it)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessageId = R.string.error_message_find_user,
-                    )
-                }
-            }
         }
     }
 
     fun deleteStudyGroupMember(userId: String, studyGroupId: String) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
-            studyGroupRepository.deleteUser(studyGroupId, userId).onSuccess {
-                deleteUserGroup(userId, studyGroupId)
+            studyGroupRepository.deleteUser(studyGroupId, userId)
+                .onSuccess {
+                    deleteUserGroup(userId, studyGroupId)
 
-            }.onFailure {
-                Log.e("DetailStudyViewModel", "Failed to delete study group member", it)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessageId = R.string.error_message_delete_study_group_member,
-                    )
+                }.onFailure {
+                    Log.e("DetailStudyViewModel", "Failed to delete study group member", it)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessageId = R.string.error_message_delete_study_group_member,
+                        )
+                    }
                 }
-            }
         }
     }
 
     private fun deleteUserGroup(userId: String, groupId: String) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
-            userRepository.deleteStudyGroupUser(userId, groupId).onSuccess {
-                loadStudyGroup(groupId)
-            }.onFailure {
-                Log.e("DetailStudyViewModel", "Failed to delete study group member", it)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessageId = R.string.error_message_delete_users_group,
-                    )
+            userRepository.deleteStudyGroupUser(userId, groupId)
+                .onSuccess {
+                    loadStudyGroup()
+                }.onFailure {
+                    Log.e("DetailStudyViewModel", "Failed to delete study group member", it)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessageId = R.string.error_message_delete_users_group,
+                        )
+                    }
                 }
+        }
+    }
+
+    fun leaveStudyGroup(studyGroup: StudyGroup) {
+        uiState.value.userId?.let { user ->
+            when (studyGroup.ownerId == user) {
+                true -> removeStudyGroup(studyGroup)
+                false -> removeUserFromStudyGroup(user, studyGroup.id)
             }
+        }
+    }
+
+    private fun removeStudyGroup(studyGroup: StudyGroup) {
+        viewModelScope.launch {
+            categoryRepository.getCategories(studyGroup.categories)
+                .onSuccess { categories ->
+                    quizRepository.getQuizList(categories.flatMap { it.quizzes })
+                        .onSuccess { quizzes ->
+                            questionRepository.deleteQuestions(quizzes.flatMap { it.questions })
+                                .onSuccess {
+                                    userOmrRepository.deleteUserOmrs(quizzes.flatMap { it.userOmrs })
+                                        .onSuccess {
+                                            quizRepository.deleteQuizzes(quizzes.map { it.id })
+                                                .onSuccess {
+                                                    categoryRepository.deleteCategories(categories.map { it.id })
+                                                        .onSuccess {
+                                                            notificationRepository.deleteNotification(notificationId = studyGroup.id)
+                                                                .onSuccess {
+                                                                    userRepository.deleteStudyGroupUsers(studyGroup.users, studyGroup.id)
+                                                                        .onSuccess {
+                                                                            studyGroupRepository.deleteStudyGroup(studyGroup.id)
+                                                                                .onSuccess {
+                                                                                    Log.d("MainViewModel", "스터디 그룹 삭제 완료")
+                                                                                    loadCurrentUser() // 스터디 그룹 최신화
+                                                                                }
+                                                                                .onFailure {
+                                                                                    Log.e("MainViewModel", "Failed to remove study group", it)
+                                                                                    _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                                                                                }
+                                                                        }
+                                                                        .onFailure {
+                                                                            Log.e("MainViewModel", "Failed to remove users from study group", it)
+                                                                            _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                                                                        }
+                                                                }
+                                                                .onFailure {
+                                                                    Log.e("MainViewModel", "Failed to remove notification", it)
+                                                                    _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                                                                }
+                                                        }
+                                                        .onFailure {
+                                                            Log.e("MainViewModel", "Failed to remove categories from study group", it)
+                                                            _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                                                        }
+                                                }
+                                                .onFailure {
+                                                    Log.e("MainViewModel", "Failed to remove quizzes from study group", it)
+                                                    _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                                                }
+                                        }
+                                        .onFailure {
+                                            Log.e("MainViewModel", "Failed to remove userOmr from study group", it)
+                                            _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                                        }
+                                }
+                                .onFailure {
+                                    Log.e("MainViewModel", "Failed to remove questions from study group", it)
+                                    _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                                }
+                        }
+                        .onFailure {
+                            Log.e("MainViewModel", "Failed to remove quizzes from study group", it)
+                            _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                        }
+                }
+                .onFailure {
+                    Log.e("MainViewModel", "Failed to remove categories from study group", it)
+                    _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                }
+        }
+    }
+
+    private fun removeUserFromStudyGroup(userId: String, studyGroupId: String) {
+        viewModelScope.launch {
+            userRepository.deleteStudyGroupUser(userId, studyGroupId)
+                .onSuccess {
+                    studyGroupRepository.deleteUser(studyGroupId, userId)
+                        .onSuccess {
+                            loadCurrentUser()
+                        }
+                        .onFailure {
+                            Log.e("MainViewModel", "Failed to remove user from study group", it)
+                            _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                        }
+                }
+                .onFailure {
+                    Log.e("MainViewModel", "Failed to remove user from study group", it)
+                    _uiState.update { it.copy(errorMessageId = R.string.error_message_delete_study_group) }
+                }
         }
     }
 

--- a/feature/study/src/main/res/drawable/img_photo_picker.xml
+++ b/feature/study/src/main/res/drawable/img_photo_picker.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="400dp"
+    android:height="400dp"
+    android:viewportWidth="400"
+    android:viewportHeight="400">
+  <path
+      android:pathData="M0,0h400v400h-400z"
+      android:fillColor="#DADCE0"/>
+  <path
+      android:pathData="M164,166L236,166A20,20 0,0 1,256 186L256,225A20,20 0,0 1,236 245L164,245A20,20 0,0 1,144 225L144,186A20,20 0,0 1,164 166z"
+      android:fillColor="#9AA0A6"/>
+  <path
+      android:pathData="M176,206a23.5,24 0,1 0,47 0a23.5,24 0,1 0,-47 0z"
+      android:fillColor="#DADCE0"/>
+  <path
+      android:pathData="M199.5,206.5m-12.5,0a12.5,12.5 0,1 1,25 0a12.5,12.5 0,1 1,-25 0"
+      android:fillColor="#9AA0A6"/>
+  <path
+      android:pathData="M229.5,155L229.5,155A11.5,11.5 0,0 1,241 166.5L241,170.5A11.5,11.5 0,0 1,229.5 182L229.5,182A11.5,11.5 0,0 1,218 170.5L218,166.5A11.5,11.5 0,0 1,229.5 155z"
+      android:fillColor="#9AA0A6"/>
+</vector>

--- a/feature/study/src/main/res/values/strings.xml
+++ b/feature/study/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="txt_create_study_group_number_error_message">2에서 50 사이의 정수를 입력해주세요.</string>
     <string name="txt_edit_study_top_app_bar">스터디 수정</string>
     <string name="txt_study_edition_button">스터디 수정</string>
+    <string name="des_study_group_image">스터디 배경 이미지</string>
     <string-array name="drop_down_menu_options">
         <item>1명</item>
         <item>2명</item>

--- a/feature/study/src/main/res/values/strings.xml
+++ b/feature/study/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="error_message_delete_study_group_member">스터디 그룹의 멤버 삭제가 실패했습니다.</string>
     <string name="error_message_add_notification">알림 추가가 실패했습니다.</string>
     <string name="error_message_find_user">유저 조회에 실패했습니다.</string>
+    <string name="error_message_delete_study_group">스터디 그룹에서 나가지 못했습니다.</string>
     <string-array name="drop_down_menu_options">
         <item>1명</item>
         <item>2명</item>

--- a/feature/study/src/main/res/values/strings.xml
+++ b/feature/study/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="txt_create_study_group_member_number_label">인원</string>
     <string name="txt_create_study_group_member_number_placeholder">최대 인원은 몇 명인가요?</string>
     <string name="txt_create_study_group_number_error_message">2에서 50 사이의 정수를 입력해주세요.</string>
+    <string name="txt_edit_study_top_app_bar">스터디 수정</string>
+    <string name="txt_study_edition_button">스터디 수정</string>
     <string-array name="drop_down_menu_options">
         <item>1명</item>
         <item>2명</item>

--- a/feature/study/src/main/res/values/strings.xml
+++ b/feature/study/src/main/res/values/strings.xml
@@ -46,6 +46,9 @@
     <string name="error_message_add_notification">알림 추가가 실패했습니다.</string>
     <string name="error_message_find_user">유저 조회에 실패했습니다.</string>
     <string name="error_message_delete_study_group">스터디 그룹에서 나가지 못했습니다.</string>
+    <string name="txt_create_study_group_member_number_label">인원</string>
+    <string name="txt_create_study_group_member_number_placeholder">최대 인원은 몇 명인가요?</string>
+    <string name="txt_create_study_group_number_error_message">2에서 50 사이의 정수를 입력해주세요.</string>
     <string-array name="drop_down_menu_options">
         <item>1명</item>
         <item>2명</item>

--- a/feature/study/src/main/res/values/strings.xml
+++ b/feature/study/src/main/res/values/strings.xml
@@ -36,6 +36,9 @@
     <string name="assist_chip_detail_study_group_member_number">%1$s명 / %2$s명</string>
     <string name="txt_detail_study_no_category_description">내용 없음</string>
     <string name="txt_detail_study_no_category_owner">비회원</string>
+    <string name="txt_study_group_menu_edit">수정</string>
+    <string name="txt_study_group_menu_delete">스터디 제거</string>
+    <string name="txt_study_group_menu_leave">나가기</string>
     <string name="error_message_load_study_group">스터디 그룹 로드에 실패했습니다.</string>
     <string name="error_message_load_categories">카테고리 로드에 실패했습니다.</string>
     <string name="error_message_load_users">유저 로드에 실패했습니다.</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compil
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
+firebase-storage = { group = "com.google.firebase", name = "firebase-storage" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltAndroidCompiler" }


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
✅메인 화면 스터디 메뉴 보여주기
- 그룹장이면 수정 / 나가기
- 그룹원이면 나가기

✅그룹 나가기
- 스터디가 없어지면 (스터디그룹, 유저, 카테고리, 퀴즈, 문제 DB 삭제)

✅스터디 상세 화면
- 스터디 수정 기능(그룹장인 경우)
- 스터디 삭제 기능(그룹장인 경우)
- 스터디 나가기 기능(그룹원인 경우)
- 드롭다운 메뉴 구현

✅스터디 생성 화면
- 이미지 추가 기능
- 그룹원 수 DropDownMenu에서 TextField로 변경

### 📷 작업 결과(사진)
https://github.com/user-attachments/assets/9baa6a9f-8d37-4e8e-aa6c-2fdf1a4af5ad

### 🗣️ 공유할 내용
- StudyGroup 삭제 시 관련된 모든 DB를 삭제하도록 했습니다.
    - 모두 삭제했을 시 성공 처리를 했습니다. (실패하면 되돌릴 수 없습니다)
- StudyGroup 수정 시 기존 이미지를 제거하고 새로운 이미지를 업로드하였습니다.
    - 만약에 수정되지 않았으면 기존 이미지 uri을 유지합니다.
- WeQuizAsyncImage 매개변수로 imgUrl을 `Any?`로 수정했습니다.

closed #120
