### PR TITLE
feat: 퀴즈 시작 화면 실시간 반영

### DIFF
--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -83,7 +83,7 @@ fun WeQuizNavHost(
             onStartQuizButtonClick = navController::navigateQuestion,
             onSettingMenuClick = navController::navigateCreateQuiz,
             onEditQuizSuccess = navController::navigateUp,
-            onQuizDeleted = navController::navigateUp,
+            onQuizDeleteSuccess = navController::navigateUp,
         )
     }
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     implementation(libs.material)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
+    implementation(libs.kotlinx.coroutines)
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/model/RealTimeQuizDTO.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/model/RealTimeQuizDTO.kt
@@ -27,7 +27,7 @@ data class RealTimeQuizDTO(
     var isFinished: Boolean? = null,
     @get:PropertyName("waiting_users")
     @set:PropertyName("waiting_users")
-    var waitingUsers: Int? = null,
+    var waitingUsers: List<String>? = null,
     @get:PropertyName("quiz_image_url")
     @set:PropertyName("quiz_image_url")
     var quizImageUrl: String? = null,

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
@@ -130,7 +130,7 @@ class QuizRepositoryImpl @Inject constructor(
         val listener = quizCollectionRef.document(quizId)
             .addSnapshotListener { snapshot, error ->
                 if (error != null) {
-                    return@addSnapshotListener
+                    close(error)
                 }
 
                 if (snapshot != null && snapshot.exists()) {

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
@@ -109,6 +109,23 @@ class QuizRepositoryImpl @Inject constructor(
                 .await()
         }
 
+    override suspend fun waitingRealTimeQuiz(quizId: String, waiting: Boolean, userId: String): Result<Unit> =
+        runCatching {
+            when (waiting) {
+                true -> {
+                    quizCollectionRef.document(quizId)
+                        .update("waiting_users", FieldValue.arrayUnion(userId))
+                        .await()
+                }
+
+                false -> {
+                    quizCollectionRef.document(quizId)
+                        .update("waiting_users", FieldValue.arrayRemove(userId))
+                        .await()
+                }
+            }
+        }
+
     override fun getQuizFlow(quizId: String): Flow<BaseQuiz> = callbackFlow<BaseQuiz> {
         val listener = quizCollectionRef.document(quizId)
             .addSnapshotListener { snapshot, error ->

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
@@ -101,11 +101,8 @@ class QuizRepositoryImpl @Inject constructor(
 
     override suspend fun startRealTimeQuiz(quizId: String): Result<Unit> =
         runCatching {
-            val updatedData = mapOf(
-                "is_started" to true,
-            )
             quizCollectionRef.document(quizId)
-                .update(updatedData)
+                .update("is_started", true)
                 .await()
         }
 
@@ -126,14 +123,14 @@ class QuizRepositoryImpl @Inject constructor(
             }
         }
 
-    override fun getQuizFlow(quizId: String): Flow<BaseQuiz> = callbackFlow<BaseQuiz> {
+    override fun observeQuiz(quizId: String): Flow<BaseQuiz> = callbackFlow<BaseQuiz> {
         val listener = quizCollectionRef.document(quizId)
             .addSnapshotListener { snapshot, error ->
                 if (error != null) {
                     close(error)
                 }
 
-                if (snapshot != null && snapshot.exists()) {
+                if (snapshot?.exists() == true) {
                     try {
                         val quizType = snapshot.get("type").toString()
                         val response = when (getQuizTypeFromValue(quizType)) {

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
@@ -2,6 +2,9 @@ package kr.boostcamp_2024.course.data.repository
 
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import kr.boostcamp_2024.course.data.model.QuizDTO
 import kr.boostcamp_2024.course.data.model.RealTimeQuizDTO
@@ -95,4 +98,33 @@ class QuizRepositoryImpl @Inject constructor(
                 quizCollectionRef.document(quizId).delete().await()
             }
         }
+
+    override fun getQuizFlow(quizId: String): Flow<BaseQuiz> = callbackFlow<BaseQuiz> {
+        val listener = quizCollectionRef.document(quizId)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    return@addSnapshotListener
+                }
+
+                if (snapshot != null && snapshot.exists()) {
+                    try {
+                        val quizType = snapshot.get("type").toString()
+                        val response = when (getQuizTypeFromValue(quizType)) {
+                            RealTime -> snapshot.toObject(RealTimeQuizDTO::class.java)?.toVO(quizId)
+                            General -> snapshot.toObject(QuizDTO::class.java)?.toVO(quizId)
+                        }
+                        val quiz =
+                            requireNotNull(response) { "Quiz response is null for quizId: $quizId" }
+                        trySend(quiz)
+                    } catch (exception: Exception) {
+                        close(exception)
+                    }
+                } else {
+                    close(Exception("Quiz not found"))
+                }
+            }
+        awaitClose {
+            listener.remove()
+        }
+    }
 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
@@ -99,6 +99,16 @@ class QuizRepositoryImpl @Inject constructor(
             }
         }
 
+    override suspend fun startRealTimeQuiz(quizId: String): Result<Unit> =
+        runCatching {
+            val updatedData = mapOf(
+                "is_started" to true,
+            )
+            quizCollectionRef.document(quizId)
+                .update(updatedData)
+                .await()
+        }
+
     override fun getQuizFlow(quizId: String): Flow<BaseQuiz> = callbackFlow<BaseQuiz> {
         val listener = quizCollectionRef.document(quizId)
             .addSnapshotListener { snapshot, error ->

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -13,3 +13,7 @@ kotlin {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
+
+dependencies {
+    implementation(libs.kotlinx.coroutines)
+}

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/RealtimeQuiz.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/RealtimeQuiz.kt
@@ -19,6 +19,6 @@ data class RealTimeQuiz(
     val ownerId: String,
     val isStarted: Boolean,
     val isFinished: Boolean,
-    val waitingUsers: Int,
+    val waitingUsers: List<String>,
     override val quizImageUrl: String?,
 ) : BaseQuiz()

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
@@ -23,5 +23,7 @@ interface QuizRepository {
 
     suspend fun startRealTimeQuiz(quizId: String): Result<Unit>
 
+    suspend fun waitingRealTimeQuiz(quizId: String, waiting: Boolean, userId: String): Result<Unit>
+
     fun getQuizFlow(quizId: String): Flow<BaseQuiz>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.domain.repository
 
+import kotlinx.coroutines.flow.Flow
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
 import kr.boostcamp_2024.course.domain.model.QuizCreationInfo
 
@@ -19,4 +20,6 @@ interface QuizRepository {
     suspend fun deleteQuiz(quizId: String): Result<Unit>
 
     suspend fun deleteQuizzes(quizzes: List<String>): Result<Unit>
+
+    fun getQuizFlow(quizId: String): Flow<BaseQuiz>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
@@ -25,5 +25,5 @@ interface QuizRepository {
 
     suspend fun waitingRealTimeQuiz(quizId: String, waiting: Boolean, userId: String): Result<Unit>
 
-    fun getQuizFlow(quizId: String): Flow<BaseQuiz>
+    fun observeQuiz(quizId: String): Flow<BaseQuiz>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
@@ -21,5 +21,7 @@ interface QuizRepository {
 
     suspend fun deleteQuizzes(quizzes: List<String>): Result<Unit>
 
+    suspend fun startRealTimeQuiz(quizId: String): Result<Unit>
+
     fun getQuizFlow(quizId: String): Flow<BaseQuiz>
 }

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.category.presentation
 
+import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -88,6 +89,7 @@ fun CreateCategoryScreen(
     )
 }
 
+@SuppressLint("NewApi")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateCategoryScreen(
@@ -111,7 +113,7 @@ fun CreateCategoryScreen(
             val bitmap = BitmapFactory.decodeStream(inputStream)
 
             val baos = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 50, baos)
+            bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSY, 50, baos)
             val data = baos.toByteArray()
 
             onCurrentCategoryImageChanged(data)

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
@@ -1,6 +1,5 @@
 package kr.boostcamp_2024.course.category.presentation
 
-import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -89,7 +88,6 @@ fun CreateCategoryScreen(
     )
 }
 
-@SuppressLint("NewApi")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateCategoryScreen(

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
@@ -111,7 +111,7 @@ fun CreateCategoryScreen(
             val bitmap = BitmapFactory.decodeStream(inputStream)
 
             val baos = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSY, 50, baos)
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 70, baos)
             val data = baos.toByteArray()
 
             onCurrentCategoryImageChanged(data)

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -80,15 +80,15 @@ fun QuizDataButton(
                     if (quiz.questions.isEmpty()) { // (참여자, 관리자) -> 문제가 없는 경우
                         Text(text = stringResource(R.string.txt_quiz_question_count_zero))
                     } else if (isOwner && quiz.isStarted.not()) { // (관리자) -> 퀴즈 시작 전
-                        Text(text = "시작 하기(대기: ${quiz.waitingUsers.size}명)")
+                        Text(text = stringResource(R.string.txt_real_time_quiz_owner, quiz.waitingUsers.size))
                     } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not()) { // (참여자) -> 퀴즈 시작 전
-                        Text(text = "대기하기")
+                        Text(text = stringResource(R.string.txt_real_time_quiz_wait_false))
                     } else if (isOwner.not() && quiz.isStarted.not() && isWaiting) { // (참여자) -> 대기 중
-                        Text(text = "대기: ${quiz.waitingUsers.size}명")
+                        Text(text = stringResource(R.string.txt_real_time_quiz_wait_true, quiz.waitingUsers.size))
                     } else if (quiz.isStarted && quiz.isFinished.not()) { // (참여자, 관리자) -> 퀴즈 진행 중
-                        Text(text = "퀴즈 진행 중")
+                        Text(text = stringResource(R.string.txt_real_time_quiz_progressing))
                     } else if (quiz.isFinished) { // (참여자, 관리자) -> 퀴즈 종료
-                        Text(text = "시험이 끝났습니다.")
+                        Text(text = stringResource(R.string.txt_real_time_quiz_finished))
                     }
                 }
             }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -14,74 +14,87 @@ import kr.boostcamp_2024.course.quiz.R
 @Composable
 fun QuizDataButton(
     quiz: BaseQuiz?,
-    isOwner: Boolean,
-    isWaiting: Boolean,
+    currentUserId: String?,
     onCreateQuestionButtonClick: (String) -> Unit,
     onStartQuizButtonClick: (String) -> Unit,
+    onStartRealTimeQuizButtonClick: () -> Unit,
+    onWaitingRealTimeQuizButtonClick: (Boolean) -> Unit,
 ) {
-    when (quiz) {
-        is Quiz -> {
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onCreateQuestionButtonClick(quiz.id) },
-                enabled = quiz.isOpened.not(),
-            ) {
-                when (quiz.isOpened.not()) {
-                    true -> Text(text = stringResource(R.string.txt_open_create_question))
-                    false -> Text(text = stringResource(R.string.txt_close_create_question))
+    currentUserId?.let { currentUserId ->
+        when (quiz) {
+            is Quiz -> {
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { onCreateQuestionButtonClick(quiz.id) },
+                    enabled = quiz.isOpened.not(),
+                ) {
+                    when (quiz.isOpened.not()) {
+                        true -> Text(text = stringResource(R.string.txt_open_create_question))
+                        false -> Text(text = stringResource(R.string.txt_close_create_question))
+                    }
+                }
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { onStartQuizButtonClick(quiz.id) },
+                    enabled = (quiz.isOpened && quiz.questions.isNotEmpty()),
+                ) {
+                    when (quiz.isOpened && quiz.questions.isEmpty()) {
+                        true -> Text(text = stringResource(R.string.txt_quiz_question_count_zero))
+                        false -> Text(text = stringResource(R.string.txt_quiz_start))
+                    }
                 }
             }
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onStartQuizButtonClick(quiz.id) },
-                enabled = (quiz.isOpened && quiz.questions.isNotEmpty()),
-            ) {
-                when (quiz.isOpened && quiz.questions.isEmpty()) {
-                    true -> Text(text = stringResource(R.string.txt_quiz_question_count_zero))
-                    false -> Text(text = stringResource(R.string.txt_quiz_start))
-                }
-            }
-        }
 
-        is RealTimeQuiz -> {
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onCreateQuestionButtonClick(quiz.id) },
-                enabled = quiz.isStarted.not(),
-            ) {
-                when (quiz.isStarted.not()) {
-                    true -> Text(text = stringResource(R.string.txt_open_create_question))
-                    false -> Text(text = stringResource(R.string.txt_close_create_question))
+            is RealTimeQuiz -> {
+                val isOwner = quiz.ownerId == currentUserId
+                val isWaiting = quiz.waitingUsers.contains(currentUserId)
+
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { onCreateQuestionButtonClick(quiz.id) },
+                    enabled = quiz.isStarted.not() && isWaiting.not(),
+                ) {
+                    when (quiz.isStarted.not()) {
+                        true -> Text(text = stringResource(R.string.txt_open_create_question))
+                        false -> Text(text = stringResource(R.string.txt_close_create_question))
+                    }
                 }
-            }
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onStartQuizButtonClick(quiz.id) },
-                enabled =
-                    if (isOwner && quiz.isStarted.not() && quiz.waitingUsers.isNotEmpty() && quiz.questions.isNotEmpty()) { // (관리자) -> 퀴즈 시작 전
-                        true
-                    } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not() && quiz.questions.isNotEmpty()) { // (참여자) -> 퀴즈 시작 전
-                        true
-                    } else {
-                        false
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        if (isOwner && quiz.isStarted.not() && quiz.waitingUsers.isNotEmpty() && quiz.questions.isNotEmpty()) { // (관리자) -> 퀴즈 시작 전
+                            onStartRealTimeQuizButtonClick()
+                        } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not() && quiz.questions.isNotEmpty()) { // (참여자) -> 퀴즈 시작 전
+                            onWaitingRealTimeQuizButtonClick(true)
+                        }
                     },
-            ) {
-                if (quiz.questions.isEmpty()) { // (참여자, 관리자) -> 문제가 없는 경우
-                    Text(text = stringResource(R.string.txt_quiz_question_count_zero))
-                } else if (isOwner && quiz.isStarted.not()) { // (관리자) -> 퀴즈 시작 전
-                    Text(text = "시작 하기(대기: ${quiz.waitingUsers.size}명)")
-                } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not()) { // (참여자) -> 퀴즈 시작 전
-                    Text(text = "대기하기")
-                } else if (isOwner.not() && quiz.isStarted.not() && isWaiting) { // (참여자) -> 대기 중
-                    Text(text = "대기: ${quiz.waitingUsers}명")
-                } else if (quiz.isStarted && quiz.isFinished.not()) { // (참여자, 관리자) -> 퀴즈 진행 중
-                    Text(text = "퀴즈 진행 중")
-                } else if (quiz.isFinished) { // (참여자, 관리자) -> 퀴즈 종료
-                    Text(text = "시험이 끝났습니다.")
+                    enabled =
+                        if (isOwner && quiz.isStarted.not() && quiz.waitingUsers.isNotEmpty() && quiz.questions.isNotEmpty()) { // (관리자) -> 퀴즈 시작 전
+                            true
+                        } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not() && quiz.questions.isNotEmpty()) { // (참여자) -> 퀴즈 시작 전
+                            true
+                        } else {
+                            false
+                        },
+                ) {
+                    if (quiz.questions.isEmpty()) { // (참여자, 관리자) -> 문제가 없는 경우
+                        Text(text = stringResource(R.string.txt_quiz_question_count_zero))
+                    } else if (isOwner && quiz.isStarted.not()) { // (관리자) -> 퀴즈 시작 전
+                        Text(text = "시작 하기(대기: ${quiz.waitingUsers.size}명)")
+                    } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not()) { // (참여자) -> 퀴즈 시작 전
+                        Text(text = "대기하기")
+                    } else if (isOwner.not() && quiz.isStarted.not() && isWaiting) { // (참여자) -> 대기 중
+                        Text(text = "대기: ${quiz.waitingUsers.size}명")
+                    } else if (quiz.isStarted && quiz.isFinished.not()) { // (참여자, 관리자) -> 퀴즈 진행 중
+                        Text(text = "퀴즈 진행 중")
+                    } else if (quiz.isFinished) { // (참여자, 관리자) -> 퀴즈 종료
+                        Text(text = "시험이 끝났습니다.")
+                    }
                 }
             }
-        }
 
-        null -> {}
+            null -> { // no-op
+            }
+        }
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -1,0 +1,50 @@
+package kr.boostcamp_2024.course.quiz.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import kr.boostcamp_2024.course.domain.model.BaseQuiz
+import kr.boostcamp_2024.course.domain.model.Quiz
+import kr.boostcamp_2024.course.domain.model.RealTimeQuiz
+import kr.boostcamp_2024.course.quiz.R
+
+@Composable
+fun QuizDataButton(
+    quiz: BaseQuiz?,
+    onCreateQuestionButtonClick: (String) -> Unit,
+    onStartQuizButtonClick: (String) -> Unit,
+) {
+    when (quiz) {
+        is Quiz -> {
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onCreateQuestionButtonClick(quiz.id) },
+                enabled = quiz.isOpened.not(),
+            ) {
+                when (quiz.isOpened.not()) {
+                    true -> Text(text = stringResource(R.string.txt_open_create_question))
+                    false -> Text(text = stringResource(R.string.txt_close_create_question))
+                }
+            }
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onStartQuizButtonClick(quiz.id) },
+                enabled = (quiz.isOpened && quiz.questions.isNotEmpty()),
+            ) {
+                when (quiz.isOpened && quiz.questions.isEmpty()) {
+                    true -> Text(text = stringResource(R.string.txt_quiz_question_count_zero))
+                    false -> Text(text = stringResource(R.string.txt_quiz_start))
+                }
+            }
+        }
+
+        is RealTimeQuiz -> {
+
+        }
+
+        null -> {}
+    }
+}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -14,6 +14,8 @@ import kr.boostcamp_2024.course.quiz.R
 @Composable
 fun QuizDataButton(
     quiz: BaseQuiz?,
+    isOwner: Boolean,
+    isWaiting: Boolean,
     onCreateQuestionButtonClick: (String) -> Unit,
     onStartQuizButtonClick: (String) -> Unit,
 ) {
@@ -42,7 +44,35 @@ fun QuizDataButton(
         }
 
         is RealTimeQuiz -> {
-
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onCreateQuestionButtonClick(quiz.id) },
+                enabled = quiz.isStarted.not(),
+            ) {
+                when (quiz.isStarted.not()) {
+                    true -> Text(text = stringResource(R.string.txt_open_create_question))
+                    false -> Text(text = stringResource(R.string.txt_close_create_question))
+                }
+            }
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onStartQuizButtonClick(quiz.id) },
+                enabled = true,
+            ) {
+                if (quiz.questions.isEmpty()) { // (참여자, 관리자) -> 문제가 없는 경우
+                    Text(text = stringResource(R.string.txt_quiz_question_count_zero))
+                } else if (isOwner && quiz.isStarted.not()) { // (관리자) -> 퀴즈 시작 전
+                    Text(text = "시작 하기(대기: ${quiz.waitingUsers}명)")
+                } else if (isOwner.not() && quiz.isStarted.not()) { // (참여자) -> 퀴즈 시작 전
+                    Text(text = "대기하기")
+                } else if (isOwner.not() && quiz.isStarted.not() && isWaiting) { // (참여자) -> 대기 중
+                    Text(text = "대기: ${quiz.waitingUsers}명")
+                } else if (quiz.isStarted && quiz.isFinished.not()) { // (참여자, 관리자) -> 퀴즈 진행 중
+                    Text(text = "퀴즈 진행 중")
+                } else if (quiz.isFinished) { // (참여자, 관리자) -> 퀴즈 종료
+                    Text(text = "시험이 끝났습니다.")
+                }
+            }
         }
 
         null -> {}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -57,13 +57,20 @@ fun QuizDataButton(
             Button(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = { onStartQuizButtonClick(quiz.id) },
-                enabled = true,
+                enabled =
+                    if (isOwner && quiz.isStarted.not() && quiz.waitingUsers.isNotEmpty() && quiz.questions.isNotEmpty()) { // (관리자) -> 퀴즈 시작 전
+                        true
+                    } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not() && quiz.questions.isNotEmpty()) { // (참여자) -> 퀴즈 시작 전
+                        true
+                    } else {
+                        false
+                    },
             ) {
                 if (quiz.questions.isEmpty()) { // (참여자, 관리자) -> 문제가 없는 경우
                     Text(text = stringResource(R.string.txt_quiz_question_count_zero))
                 } else if (isOwner && quiz.isStarted.not()) { // (관리자) -> 퀴즈 시작 전
-                    Text(text = "시작 하기(대기: ${quiz.waitingUsers}명)")
-                } else if (isOwner.not() && quiz.isStarted.not()) { // (참여자) -> 퀴즈 시작 전
+                    Text(text = "시작 하기(대기: ${quiz.waitingUsers.size}명)")
+                } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not()) { // (참여자) -> 퀴즈 시작 전
                     Text(text = "대기하기")
                 } else if (isOwner.not() && quiz.isStarted.not() && isWaiting) { // (참여자) -> 대기 중
                     Text(text = "대기: ${quiz.waitingUsers}명")

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
@@ -46,8 +47,15 @@ fun QuizDataButton(
             }
 
             is RealTimeQuiz -> {
-                val isOwner = quiz.ownerId == currentUserId
-                val isWaiting = quiz.waitingUsers.contains(currentUserId)
+                val isOwner = remember(quiz) { quiz.ownerId == currentUserId }
+                val isParticipant = remember(quiz) { isOwner.not() }
+                val isWaiting = remember(quiz) { quiz.waitingUsers.contains(currentUserId) }
+                val isProgress = remember(quiz) { (quiz.isStarted && quiz.isFinished.not()) }
+                val isOwnerBeforeQuizStart = remember(quiz) { isOwner && quiz.isStarted.not() }
+                val isParticipantBeforeQuizStart = remember(quiz) { isParticipant && quiz.isStarted.not() && isWaiting.not() }
+                val isParticipantWaiting = remember(quiz) { isParticipant && quiz.isStarted.not() && isWaiting }
+                val isStartRealTimeQuizEnabled = remember(quiz) { isOwner && quiz.isStarted.not() && quiz.waitingUsers.isNotEmpty() && quiz.questions.isNotEmpty() }
+                val isWaitingRealTimeQuizEnabled = remember(quiz) { isParticipant && quiz.isStarted.not() && isWaiting.not() && quiz.questions.isNotEmpty() }
 
                 Button(
                     modifier = Modifier.fillMaxWidth(),
@@ -62,30 +70,23 @@ fun QuizDataButton(
                 Button(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = {
-                        if (isOwner && quiz.isStarted.not() && quiz.waitingUsers.isNotEmpty() && quiz.questions.isNotEmpty()) { // (관리자) -> 퀴즈 시작 전
-                            onStartRealTimeQuizButtonClick()
-                        } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not() && quiz.questions.isNotEmpty()) { // (참여자) -> 퀴즈 시작 전
+                        if (isStartRealTimeQuizEnabled) {
+                            onStartRealTimeQuizButtonClick
+                        } else if (isWaitingRealTimeQuizEnabled) {
                             onWaitingRealTimeQuizButtonClick(true)
                         }
                     },
-                    enabled =
-                        if (isOwner && quiz.isStarted.not() && quiz.waitingUsers.isNotEmpty() && quiz.questions.isNotEmpty()) { // (관리자) -> 퀴즈 시작 전
-                            true
-                        } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not() && quiz.questions.isNotEmpty()) { // (참여자) -> 퀴즈 시작 전
-                            true
-                        } else {
-                            false
-                        },
+                    enabled = isStartRealTimeQuizEnabled || isWaitingRealTimeQuizEnabled,
                 ) {
                     if (quiz.questions.isEmpty()) { // (참여자, 관리자) -> 문제가 없는 경우
                         Text(text = stringResource(R.string.txt_quiz_question_count_zero))
-                    } else if (isOwner && quiz.isStarted.not()) { // (관리자) -> 퀴즈 시작 전
+                    } else if (isOwnerBeforeQuizStart) { // (관리자) -> 퀴즈 시작 전
                         Text(text = stringResource(R.string.txt_real_time_quiz_owner, quiz.waitingUsers.size))
-                    } else if (isOwner.not() && quiz.isStarted.not() && isWaiting.not()) { // (참여자) -> 퀴즈 시작 전
+                    } else if (isParticipantBeforeQuizStart) { // (참여자) -> 퀴즈 시작 전
                         Text(text = stringResource(R.string.txt_real_time_quiz_wait_false))
-                    } else if (isOwner.not() && quiz.isStarted.not() && isWaiting) { // (참여자) -> 대기 중
+                    } else if (isParticipantWaiting) { // (참여자) -> 대기 중
                         Text(text = stringResource(R.string.txt_real_time_quiz_wait_true, quiz.waitingUsers.size))
-                    } else if (quiz.isStarted && quiz.isFinished.not()) { // (참여자, 관리자) -> 퀴즈 진행 중
+                    } else if (isProgress) { // (참여자, 관리자) -> 퀴즈 진행 중
                         Text(text = stringResource(R.string.txt_real_time_quiz_progressing))
                     } else if (quiz.isFinished) { // (참여자, 관리자) -> 퀴즈 종료
                         Text(text = stringResource(R.string.txt_real_time_quiz_finished))

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataChip.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataChip.kt
@@ -21,7 +21,7 @@ import kr.boostcamp_2024.course.domain.model.RealTimeQuiz
 import kr.boostcamp_2024.course.quiz.R
 
 @Composable
-fun QuizDataChips(
+fun QuizDataChip(
     category: Category?,
     quiz: BaseQuiz?,
 ) {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataChips.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataChips.kt
@@ -1,0 +1,87 @@
+package kr.boostcamp_2024.course.quiz.component
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.ElevatedAssistChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kr.boostcamp_2024.course.domain.model.BaseQuiz
+import kr.boostcamp_2024.course.domain.model.Category
+import kr.boostcamp_2024.course.domain.model.RealTimeQuiz
+import kr.boostcamp_2024.course.quiz.R
+
+@Composable
+fun QuizDataChips(
+    category: Category?,
+    quiz: BaseQuiz?,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+
+        quiz?.let {
+            ElevatedAssistChip(
+                onClick = { /* no-op */ },
+                label = {
+                    Text(text = stringResource(R.string.txt_quiz_question_count, quiz.questions.size))
+                },
+                leadingIcon = {
+                    Icon(
+                        modifier = Modifier.size(18.dp),
+                        painter = painterResource(R.drawable.search_24),
+                        contentDescription = null,
+                    )
+                },
+            )
+        }
+
+        category?.let {
+            ElevatedAssistChip(
+                onClick = { /* no-op */ },
+                label = {
+                    Text(
+                        text = category.name,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        modifier = Modifier.size(18.dp),
+                        painter = painterResource(R.drawable.search_24),
+                        contentDescription = null,
+                    )
+                },
+            )
+        }
+
+        if (quiz is RealTimeQuiz) {
+            ElevatedAssistChip(
+                onClick = { /* no-op */ },
+                label = {
+                    Text(text = stringResource(R.string.txt_real_time_quiz))
+                },
+                leadingIcon = {
+                    Icon(
+                        modifier = Modifier.size(18.dp),
+                        painter = painterResource(R.drawable.search_24),
+                        contentDescription = null,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataText.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataText.kt
@@ -1,0 +1,33 @@
+package kr.boostcamp_2024.course.quiz.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import kr.boostcamp_2024.course.domain.model.BaseQuiz
+
+@Composable
+fun QuizDataText(
+    quiz: BaseQuiz?,
+) {
+    quiz?.let { quiz ->
+        // QuizTitle
+        Text(
+            text = quiz.title,
+            style = MaterialTheme.typography.displayMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        // QuizDescription
+        quiz.description?.let { description ->
+            Text(
+                text = description,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
+        }
+    }
+}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
@@ -17,9 +17,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizBaseDialog
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
 import kr.boostcamp_2024.course.domain.model.Category
+import kr.boostcamp_2024.course.domain.model.RealTimeQuiz
 import kr.boostcamp_2024.course.quiz.R
 
 @Composable
@@ -27,15 +30,26 @@ import kr.boostcamp_2024.course.quiz.R
 fun QuizTopAppBar(
     category: Category?,
     quiz: BaseQuiz?,
+    currentUserId: String?,
+    onWaitingRealTimeQuizButtonClick: (Boolean) -> Unit,
     onNavigationButtonClick: () -> Unit,
     onSettingMenuClick: (String, String) -> Unit,
     onDeleteMenuClick: (String, BaseQuiz) -> Unit,
 ) {
+    var showDialog by remember { mutableStateOf(false) }
     var isSettingMenuExpanded by remember { mutableStateOf(false) }
+
     TopAppBar(
         title = {},
         navigationIcon = {
-            IconButton(onClick = onNavigationButtonClick) {
+            IconButton(
+                onClick =
+                    if (quiz is RealTimeQuiz && quiz.waitingUsers.contains(currentUserId)) {
+                        { showDialog = true }
+                    } else {
+                        { onNavigationButtonClick() }
+                    },
+            ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Default.ArrowBack,
                     contentDescription = null,
@@ -82,4 +96,19 @@ fun QuizTopAppBar(
             containerColor = Color.Transparent,
         ),
     )
+
+    if (showDialog) {
+        WeQuizBaseDialog(
+            title = "정말 나가시나요?\n입장이 취소됩니다!",
+            dialogImage = painterResource(R.drawable.quiz_system_profile),
+            confirmTitle = "나가기",
+            dismissTitle = "취소",
+            onConfirm = {
+                showDialog = false
+                onWaitingRealTimeQuizButtonClick(false)
+            },
+            onDismissRequest = { showDialog = false },
+            content = { /* no-op */ },
+        )
+    }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
@@ -99,10 +99,10 @@ fun QuizTopAppBar(
 
     if (showDialog) {
         WeQuizBaseDialog(
-            title = "정말 나가시나요?\n입장이 취소됩니다!",
+            title = stringResource(R.string.txt_waiting_cancel_dialog),
             dialogImage = painterResource(R.drawable.quiz_system_profile),
-            confirmTitle = "나가기",
-            dismissTitle = "취소",
+            confirmTitle = stringResource(R.string.txt_waiting_cancel_dialog_confirm),
+            dismissTitle = stringResource(R.string.txt_waiting_cancel_dialog_dismiss),
             onConfirm = {
                 showDialog = false
                 onWaitingRealTimeQuizButtonClick(false)

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
@@ -25,9 +25,9 @@ import kr.boostcamp_2024.course.quiz.R
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun QuizTopAppBar(
-    onNavigationButtonClick: () -> Unit,
     category: Category?,
     quiz: BaseQuiz?,
+    onNavigationButtonClick: () -> Unit,
     onSettingMenuClick: (String, String) -> Unit,
     onDeleteMenuClick: (String, BaseQuiz) -> Unit,
 ) {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizTopAppBar.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.quiz.component
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Settings
@@ -38,6 +39,12 @@ fun QuizTopAppBar(
 ) {
     var showDialog by remember { mutableStateOf(false) }
     var isSettingMenuExpanded by remember { mutableStateOf(false) }
+
+    BackHandler {
+        if (quiz is RealTimeQuiz && quiz.waitingUsers.contains(currentUserId)) {
+            showDialog = true
+        }
+    }
 
     TopAppBar(
         title = {},

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/navigation/QuizNavigation.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/navigation/QuizNavigation.kt
@@ -78,7 +78,7 @@ fun NavGraphBuilder.quizNavGraph(
     onStartQuizButtonClick: (String) -> Unit,
     onSettingMenuClick: (String, String) -> Unit,
     onEditQuizSuccess: () -> Unit,
-    onQuizDeleted: () -> Unit,
+    onQuizDeleteSuccess: () -> Unit,
 ) {
     composable<CreateQuestionRoute> {
         CreateQuestionScreen(
@@ -103,7 +103,7 @@ fun NavGraphBuilder.quizNavGraph(
             onCreateQuestionButtonClick = onCreateQuestionButtonClick,
             onStartQuizButtonClick = onStartQuizButtonClick,
             onSettingMenuClick = onSettingMenuClick,
-            onQuizDeleted = onQuizDeleted,
+            onQuizDeleteSuccess = onQuizDeleteSuccess,
         )
     }
     composable<QuizResultRoute> {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -46,14 +46,10 @@ fun QuizScreen(
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
-    if (uiState.value.isDeleteSuccess) {
+    if (uiState.value.isDeleteQuizSuccess) {
         LaunchedEffect(Unit) {
             onQuizDeleteSuccess()
         }
-    }
-
-    LaunchedEffect(Unit) {
-        viewModel.initViewModel()
     }
 
     QuizScreen(

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -71,6 +71,12 @@ fun QuizScreen(
         WeQuizCircularProgressIndicator()
     }
 
+    if (uiState.isCancelWaitingRealTimeQuizSuccess) {
+        LaunchedEffect(Unit) {
+            onNavigationButtonClick()
+        }
+    }
+
     uiState.errorMessage?.let { errorMessage ->
         LaunchedEffect(errorMessage) {
             snackbarHostState.showSnackbar(errorMessage)
@@ -100,9 +106,11 @@ fun QuizScreen(
             QuizTopAppBar(
                 category = category,
                 quiz = quiz,
+                currentUserId = currentUserId,
                 onNavigationButtonClick = onNavigationButtonClick,
                 onSettingMenuClick = onSettingMenuClick,
                 onDeleteMenuClick = onDeleteMenuClick,
+                onWaitingRealTimeQuizButtonClick = onWaitingRealTimeQuizButtonClick,
             )
         },
         snackbarHost = {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,30 +45,33 @@ fun QuizScreen(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     viewModel: QuizViewModel = hiltViewModel(),
 ) {
-    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    if (uiState.value.isDeleteQuizSuccess) {
+    if (uiState.isDeleteQuizSuccess) {
         LaunchedEffect(Unit) {
             onQuizDeleteSuccess()
         }
     }
 
     QuizScreen(
-        category = uiState.value.category,
-        quiz = uiState.value.quiz,
+        category = uiState.category,
+        quiz = uiState.quiz,
+        currentUserId = uiState.currentUserId,
         snackbarHostState = snackbarHostState,
         onNavigationButtonClick = onNavigationButtonClick,
         onCreateQuestionButtonClick = onCreateQuestionButtonClick,
         onStartQuizButtonClick = onStartQuizButtonClick,
         onSettingMenuClick = onSettingMenuClick,
         onDeleteMenuClick = viewModel::deleteQuiz,
+        onStartRealTimeQuizButtonClick = viewModel::startRealTimeQuiz,
+        onWaitingRealTimeQuizButtonClick = viewModel::waitingRealTimeQuiz,
     )
 
-    if (uiState.value.isLoading) {
+    if (uiState.isLoading) {
         WeQuizCircularProgressIndicator()
     }
 
-    uiState.value.errorMessage?.let { errorMessage ->
+    uiState.errorMessage?.let { errorMessage ->
         LaunchedEffect(errorMessage) {
             snackbarHostState.showSnackbar(errorMessage)
             viewModel.shownErrorMessage()
@@ -79,12 +83,15 @@ fun QuizScreen(
 fun QuizScreen(
     category: Category?,
     quiz: BaseQuiz?,
+    currentUserId: String?,
     snackbarHostState: SnackbarHostState,
     onNavigationButtonClick: () -> Unit,
     onCreateQuestionButtonClick: (String) -> Unit,
     onStartQuizButtonClick: (String) -> Unit,
     onSettingMenuClick: (String, String) -> Unit,
     onDeleteMenuClick: (String, BaseQuiz) -> Unit,
+    onStartRealTimeQuizButtonClick: () -> Unit,
+    onWaitingRealTimeQuizButtonClick: (Boolean) -> Unit,
 ) {
 
     Scaffold(
@@ -142,10 +149,11 @@ fun QuizScreen(
                 // QuizButton
                 QuizDataButton(
                     quiz = quiz,
-                    isOwner = true,
-                    isWaiting = false,
+                    currentUserId = currentUserId,
                     onCreateQuestionButtonClick = onCreateQuestionButtonClick,
                     onStartQuizButtonClick = onStartQuizButtonClick,
+                    onStartRealTimeQuizButtonClick = onStartRealTimeQuizButtonClick,
+                    onWaitingRealTimeQuizButtonClick = onWaitingRealTimeQuizButtonClick,
                 )
             }
         }
@@ -180,6 +188,9 @@ fun QuizStartScreenPreview() {
             onStartQuizButtonClick = {},
             onSettingMenuClick = { _, _ -> },
             onDeleteMenuClick = { _, _ -> },
+            currentUserId = "currentUserId",
+            onStartRealTimeQuizButtonClick = {},
+            onWaitingRealTimeQuizButtonClick = {},
         )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -29,6 +29,7 @@ import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizCircularPr
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
 import kr.boostcamp_2024.course.domain.model.Category
 import kr.boostcamp_2024.course.domain.model.Quiz
+import kr.boostcamp_2024.course.domain.model.RealTimeQuiz
 import kr.boostcamp_2024.course.quiz.component.QuizDataButton
 import kr.boostcamp_2024.course.quiz.component.QuizDataChip
 import kr.boostcamp_2024.course.quiz.component.QuizDataText
@@ -74,6 +75,17 @@ fun QuizScreen(
     if (uiState.isCancelWaitingRealTimeQuizSuccess) {
         LaunchedEffect(Unit) {
             onNavigationButtonClick()
+        }
+    }
+
+    val quiz = uiState.quiz
+    if (quiz is RealTimeQuiz &&
+        quiz.isStarted &&
+        quiz.isFinished.not() &&
+        (quiz.waitingUsers.contains(uiState.currentUserId) || quiz.ownerId == uiState.currentUserId)
+    ) {
+        LaunchedEffect(Unit) {
+            onStartQuizButtonClick(quiz.id)
         }
     }
 

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -146,6 +146,8 @@ fun QuizScreen(
                 // QuizButton
                 QuizDataButton(
                     quiz = quiz,
+                    isOwner = true,
+                    isWaiting = false,
                     onCreateQuestionButtonClick = onCreateQuestionButtonClick,
                     onStartQuizButtonClick = onStartQuizButtonClick,
                 )

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -9,21 +9,15 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -34,8 +28,9 @@ import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizCircularPr
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
 import kr.boostcamp_2024.course.domain.model.Category
 import kr.boostcamp_2024.course.domain.model.Quiz
-import kr.boostcamp_2024.course.quiz.R
-import kr.boostcamp_2024.course.quiz.component.QuizDataChips
+import kr.boostcamp_2024.course.quiz.component.QuizDataButton
+import kr.boostcamp_2024.course.quiz.component.QuizDataChip
+import kr.boostcamp_2024.course.quiz.component.QuizDataText
 import kr.boostcamp_2024.course.quiz.component.QuizTopAppBar
 import kr.boostcamp_2024.course.quiz.viewmodel.QuizViewModel
 
@@ -137,56 +132,23 @@ fun QuizScreen(
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
 
-                quiz?.let { quiz ->
-                    // QuizTitle
-                    Text(
-                        text = quiz.title,
-                        style = MaterialTheme.typography.displayMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-
-                    // QuizDescription
-                    quiz.description?.let { description ->
-                        Text(
-                            text = description,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                    }
-                }
+                // QuizTitle & QuizDescription
+                QuizDataText(
+                    quiz = quiz,
+                )
 
                 // QuizChip
-                QuizDataChips(
+                QuizDataChip(
                     category = category,
                     quiz = quiz,
                 )
 
-                if (quiz is Quiz) {
-                    // CreateQuestionButton & StartQuizButton
-                    Button(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = { onCreateQuestionButtonClick(quiz.id) },
-                        enabled = quiz.isOpened.not(),
-                    ) {
-                        when (quiz.isOpened.not()) {
-                            true -> Text(text = stringResource(R.string.txt_open_create_question))
-                            false -> Text(text = stringResource(R.string.txt_close_create_question))
-                        }
-
-                        Button(
-                            modifier = Modifier.fillMaxWidth(),
-                            onClick = { onStartQuizButtonClick(quiz.id) },
-                            enabled = (quiz.isOpened && quiz.questions.isNotEmpty()),
-                        ) {
-                            when (quiz.isOpened && quiz.questions.isEmpty()) {
-                                true -> Text(text = stringResource(R.string.txt_quiz_question_count_zero))
-                                false -> Text(text = stringResource(R.string.txt_quiz_start))
-                            }
-                        }
-                    }
-                }
+                // QuizButton
+                QuizDataButton(
+                    quiz = quiz,
+                    onCreateQuestionButtonClick = onCreateQuestionButtonClick,
+                    onStartQuizButtonClick = onStartQuizButtonClick,
+                )
             }
         }
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -46,7 +46,7 @@ fun QuizScreen(
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
-    if (uiState.value.isDeleted) {
+    if (uiState.value.isDeleteSuccess) {
         LaunchedEffect(Unit) {
             onQuizDeleteSuccess()
         }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuizViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuizViewModel.kt
@@ -28,7 +28,7 @@ data class QuizUiState(
     val quiz: BaseQuiz? = null,
     val currentUserId: String? = null,
     val errorMessage: String? = null,
-    val isDeleteSuccess: Boolean = false,
+    val isDeleteQuizSuccess: Boolean = false,
 )
 
 @HiltViewModel
@@ -53,6 +53,13 @@ class QuizViewModel @Inject constructor(
         loadCategory()
 
         viewModelScope.launch {
+            quizRepository.getQuizFlow(quizId)
+                .collect { quiz ->
+                    _uiState.update { it.copy(isLoading = false, quiz = quiz) }
+                }
+                .runCatching {
+                    _uiState.update { it.copy(isLoading = false, errorMessage = "퀴즈 로드에 실패했습니다.") }
+                }
         }
     }
 
@@ -111,7 +118,7 @@ class QuizViewModel @Inject constructor(
                                                         _uiState.update {
                                                             it.copy(
                                                                 isLoading = false,
-                                                                isDeleteSuccess = true,
+                                                                isDeleteQuizSuccess = true,
                                                             )
                                                         }
                                                     }
@@ -131,7 +138,7 @@ class QuizViewModel @Inject constructor(
                                             } ?: _uiState.update {
                                                 it.copy(
                                                     isLoading = false,
-                                                    isDeleteSuccess = true,
+                                                    isDeleteQuizSuccess = true,
                                                 )
                                             }
 

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuizViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuizViewModel.kt
@@ -102,7 +102,18 @@ class QuizViewModel @Inject constructor(
     }
 
     fun startRealTimeQuiz() {
-        Log.d("QuizViewModel", "startRealTimeQuiz")
+        viewModelScope.launch {
+            uiState.value.quiz?.let { quiz ->
+                quizRepository.startRealTimeQuiz(quiz.id)
+                    .onSuccess { /* no-op */ }
+                    .onFailure {
+                        Log.e("QuizViewModel", "Failed to start real-time quiz", it)
+                        _uiState.update {
+                            it.copy(isLoading = false, errorMessage = "실시간 퀴즈 시작에 실패했습니다.")
+                        }
+                    }
+            }
+        }
     }
 
     fun shownErrorMessage() {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuizViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuizViewModel.kt
@@ -97,6 +97,14 @@ class QuizViewModel @Inject constructor(
         }
     }
 
+    fun waitingRealTimeQuiz(waiting: Boolean) {
+        Log.d("QuizViewModel", "waitingRealTimeQuiz")
+    }
+
+    fun startRealTimeQuiz() {
+        Log.d("QuizViewModel", "startRealTimeQuiz")
+    }
+
     fun shownErrorMessage() {
         _uiState.update { it.copy(errorMessage = null) }
     }

--- a/feature/quiz/src/main/res/values/strings.xml
+++ b/feature/quiz/src/main/res/values/strings.xml
@@ -69,4 +69,12 @@
     <string name="txt_delete_quiz_drop_down_menu_item">퀴즈 제거</string>
     <string name="top_app_bar_edit_quiz">퀴즈 수정</string>
     <string name="txt_real_time_quiz">실시간 퀴즈</string>
+    <string name="txt_waiting_cancel_dialog">정말 나가시나요?\n입장이 취소됩니다!</string>
+    <string name="txt_waiting_cancel_dialog_confirm">나가기</string>
+    <string name="txt_waiting_cancel_dialog_dismiss">취소</string>
+    <string name="txt_real_time_quiz_owner">시작 하기(대기: %1$s명)</string>
+    <string name="txt_real_time_quiz_wait_false">대기하기</string>
+    <string name="txt_real_time_quiz_wait_true">대기: %1$s명</string>
+    <string name="txt_real_time_quiz_progressing">퀴즈 진행 중</string>
+    <string name="txt_real_time_quiz_finished">시험이 끝났습니다.</string>
 </resources>

--- a/feature/quiz/src/main/res/values/strings.xml
+++ b/feature/quiz/src/main/res/values/strings.xml
@@ -68,4 +68,5 @@
     <string name="txt_edit_quiz_drop_down_menu_item">수정</string>
     <string name="txt_delete_quiz_drop_down_menu_item">퀴즈 제거</string>
     <string name="top_app_bar_edit_quiz">퀴즈 수정</string>
+    <string name="txt_real_time_quiz">실시간 퀴즈</string>
 </resources>

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
@@ -34,8 +34,7 @@ data class CreateStudyUiState(
     val isSubmitStudySuccess: Boolean = false,
     val snackBarMessage: String? = null,
 ) {
-    val canSubmitStudy: Boolean
-        get() = (name.isNotBlank() && maxUserNum.isNotBlank() && maxUserNum.toInt() in 2..50)
+    val canSubmitStudy: Boolean = (name.isNotBlank() && maxUserNum.isNotBlank() && maxUserNum.toInt() in 2..50)
 }
 
 @HiltViewModel

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidDesugarJdkLibs = "2.1.2"
 coilNetworkOkhttp = "3.0.2"
 kotlin = "2.0.21"
 kotlinxSerializationJson = "1.7.3"
+kotlinx-coroutines = "1.7.3"
 
 # androidx
 coreKtx = "1.13.1"
@@ -62,6 +63,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 
 preferences-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "preferencesDataStore" }
 
+kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
✅ 일반 퀴즈인지 / 실시간 퀴즈인지에 따라 다르게 화면 구성
✅실시간 퀴즈 진행 전 / 진행 중 / 진행 완료에 따라 다르게 화면 구성
✅실시간 퀴즈 참여자
- 실시간 퀴즈 대기하기 api

✅실시간 퀴즈 진행자
- 실시간 퀴즈 시작하기 api

### 📷 작업 결과(사진)
https://github.com/user-attachments/assets/a20a0764-c3c7-4c96-9e8b-9656c75b654b


### 🗣️ 공유할 내용
closed #132 
