### PR TITLE
feat: (낱말 맞추기) 퀴즈 진행 화면 및 기능 구현

### DIFF
--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/model/BlankQuestionDTO.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/model/BlankQuestionDTO.kt
@@ -16,6 +16,9 @@ data class BlankQuestionDTO(
     @set:PropertyName("question_content")
     var questionContent: List<Map<String, String>>? = null,
     val type: String? = null,
+    @get:PropertyName("user_answers")
+    @set:PropertyName("user_answers")
+    var userAnswers: List<String>? = null,
 ) : QuestionDTO {
     override fun toVO(questionId: String): Question = BlankQuestion(
         id = questionId,
@@ -23,6 +26,7 @@ data class BlankQuestionDTO(
         solution = solution,
         questionContent = requireNotNull(questionContent),
         type = requireNotNull(type),
+        userAnswers = emptyList(),
     )
 }
 
@@ -31,4 +35,5 @@ fun BlankQuestionCreationInfo.toDTO() = BlankQuestionDTO(
     solution = this.solution,
     questionContent = this.questionContent,
     type = this.type,
+    userAnswers = emptyList(),
 )

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuestionRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuestionRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.data.repository
 
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -86,22 +87,30 @@ class QuestionRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateCurrentSubmit(questionId: String, selectedIndex: Int): Result<Unit> =
+    override suspend fun updateCurrentSubmit(userId: String, questionId: String, userAnswer: Any?): Result<Unit> =
         runCatching {
             val document = questionCollectionRef.document(questionId)
             firestore.runTransaction { transaction ->
                 val snapshot = transaction.get(document)
 
                 if (snapshot.exists()) {
-                    val userAnswers = snapshot.get("user_answers") as? MutableList<Int> ?: throw Exception("user_answers 배열이 존재하지 않거나 잘못되었습니다.")
+                    when (userAnswer) {
+                        is Int -> {
+                            val choices = snapshot.get("user_answers") as? MutableList<Int> ?: throw Exception("user_answers 배열이 존재하지 않거나 잘못되었습니다.")
+                            if (userAnswer in 0..3) {
+                                choices[userAnswer] += 1
+                                transaction.update(document, "user_answers", choices)
+                            } else {
+                                // no - op
+                            }
+                        }
 
-                    if (selectedIndex < 0 || selectedIndex >= userAnswers.size) {
-                        throw Exception("잘못된 인덱스입니다.")
+                        is Map<*, *> -> {
+                            transaction.update(document, "user_answers", FieldValue.arrayUnion(userId))
+                        }
+
+                        else -> throw Exception("잘못된 유저 답변입니다.")
                     }
-
-                    userAnswers[selectedIndex] += 1
-
-                    transaction.update(document, "user_answers", userAnswers)
                 } else {
                     throw Exception("문서가 존재하지 않습니다.")
                 }

--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/QuizRepositoryImpl.kt
@@ -174,11 +174,6 @@ class QuizRepositoryImpl @Inject constructor(
         }
     }
 
-    companion object {
-        private const val GENERAL_QUIZ = "general"
-        private const val REAL_TIME_QUIZ = "realTime"
-    }
-
     override fun observeRealTimeQuiz(quizId: String): Flow<Result<RealTimeQuiz>> = callbackFlow {
         val quizDocument = quizCollectionRef.document(quizId)
         val listener = quizDocument.addSnapshotListener { documentSnapshot, error ->
@@ -209,4 +204,16 @@ class QuizRepositoryImpl @Inject constructor(
                 .update("is_finished", true)
                 .await()
         }
+
+    override suspend fun updateQuizCurrentQuestion(quizId: String, currentQuestion: Int): Result<Unit> =
+        runCatching {
+            quizCollectionRef.document(quizId)
+                .update("current_question", currentQuestion)
+                .await()
+        }
+
+    companion object {
+        private const val GENERAL_QUIZ = "general"
+        private const val REAL_TIME_QUIZ = "realTime"
+    }
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -16,4 +16,5 @@ kotlin {
 
 dependencies {
     implementation(libs.kotlinx.coroutines)
+    testImplementation(libs.junit)
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/enum/BlankContentType.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/enum/BlankContentType.kt
@@ -1,0 +1,15 @@
+package kr.boostcamp_2024.course.domain.enum
+
+sealed class BlankContentType(
+    val value: String,
+) {
+    data object Text : BlankContentType("text")
+
+    data object Blank : BlankContentType("blank")
+}
+
+fun String.toBlankContentType(): BlankContentType = when (this) {
+    "text" -> BlankContentType.Text
+    "blank" -> BlankContentType.Blank
+    else -> throw IllegalArgumentException("Invalid BlankContentType value: $this")
+}

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/BlankQuestion.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/BlankQuestion.kt
@@ -4,6 +4,7 @@ data class BlankQuestion(
     override val id: String,
     override val title: String,
     override val solution: String?,
+    override val userAnswers: List<String>,
     val questionContent: List<Map<String, String>>,
     override val type: String,
 ) : Question()

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/BlankQuestionManager.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/BlankQuestionManager.kt
@@ -1,0 +1,117 @@
+package kr.boostcamp_2024.course.domain.model
+
+import kr.boostcamp_2024.course.domain.enum.BlankContentType
+import kr.boostcamp_2024.course.domain.enum.toBlankContentType
+import kotlin.math.min
+
+class BlankQuestionManager(
+    private val updateCallback: () -> Unit,
+) {
+    lateinit var contents: List<Map<String, Any>?>
+    lateinit var blankWords: List<Map<String, Any>>
+
+    fun setNewQuestions(
+        questionContents: List<Map<String, Any>>,
+        isOwner: Boolean = false,
+    ) {
+        val currentContents = mutableListOf<Map<String, Any>?>()
+        val currentBlankWords = mutableListOf<Map<String, Any>>()
+        questionContents.forEach {
+            val contentType = (it["type"] as? String)?.toBlankContentType()
+            when (contentType) {
+                BlankContentType.Text -> {
+                    currentContents.add(it)
+                }
+
+                BlankContentType.Blank -> {
+                    if (isOwner) {
+                        currentContents.add(it)
+                    } else {
+                        currentContents.add(null)
+                        currentBlankWords.add(it.initBlankQuestionContent())
+                    }
+                }
+
+                null -> throw Exception("Invalid content type")
+            }
+        }
+        contents = currentContents
+        blankWords = currentBlankWords.shuffled()
+    }
+
+    fun addBlankContent(mapIdx: Int) {
+        val targetIdx = getNullContentMinIndex()
+        updateBlankWords(mapIdx, true)
+        updateContents(targetIdx, blankWords[mapIdx])
+        updateCallback()
+    }
+
+    fun removeBlankContent(listIdx: Int) {
+        val targetContent = contents[listIdx] ?: return
+        val mapIdx = targetContent["index"] as? Int ?: return
+        updateContents(listIdx, null)
+        updateBlankWords(mapIdx, false)
+        updateCallback()
+    }
+
+    fun getNullContentMinIndex(
+        contents: List<Map<String, Any>?> = this.contents,
+    ): Int {
+        val deque = ArrayDeque<Pair<Int, Int>>()
+        deque.add(0 to contents.size - 1)
+        var minIdx = contents.size + 1
+
+        while (deque.isNotEmpty()) {
+            val (start, end) = deque.removeFirst()
+            if (start > end || start >= contents.size || end >= contents.size) continue
+
+            val mid = (start + end) / 2
+            if (contents[mid] == null) {
+                minIdx = min(minIdx, mid)
+                deque.add(start to mid - 1)
+            } else {
+                deque.add(start to mid - 1)
+                deque.add(mid + 1 to end)
+            }
+        }
+
+        return minIdx
+    }
+
+    fun getAnswer(): Map<String, String?> {
+        val blanks = contents.filter { it == null || it["type"] == "blank" }
+        return blanks.mapIndexed { index, content ->
+            index.toString() to content?.get("text") as? String
+        }.toMap()
+    }
+
+    private fun updateBlankWords(index: Int, isUsed: Boolean) {
+        blankWords = blankWords.toMutableList().apply {
+            val mapIdx = if (isUsed) index else -1
+            this[index] = this[index].setUsed(mapIdx, isUsed)
+        }
+    }
+
+    private fun updateContents(index: Int, content: Map<String, Any>?) {
+        contents = contents.toMutableList().apply {
+            this[index] = content
+        }
+    }
+}
+
+fun Map<String, Any>.setUsed(mapIdx: Int, isUsed: Boolean): Map<String, Any> =
+    this.toMutableMap().apply {
+        this["index"] = mapIdx
+        this["isUsed"] = isUsed
+    }
+
+fun Map<String, Any>.initBlankQuestionContent(): Map<String, Any> =
+    this.toMutableMap().apply {
+        this["isUsed"] = false
+        this["index"] = -1
+    }
+
+fun Map<String, Any>.setIndex(index: Int): Map<String, Any> =
+    this.toMutableMap().apply {
+        this["index"] = index
+    }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/ChoiceQuestion.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/ChoiceQuestion.kt
@@ -5,6 +5,7 @@ sealed class Question {
     abstract val title: String
     abstract val solution: String?
     abstract val type: String
+    abstract val userAnswers: List<Any>
 }
 
 data class ChoiceQuestion(
@@ -14,6 +15,6 @@ data class ChoiceQuestion(
     override val solution: String?,
     val answer: Int,
     val choices: List<String>,
-    val userAnswers: List<Int>,
+    override val userAnswers: List<Int>,
     override val type: String,
 ) : Question()

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/QuizResult.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/QuizResult.kt
@@ -35,7 +35,7 @@ data class QuizResult(
         val blankQuestion = questions[index] as BlankQuestion
         val blankQuestionContent = blankQuestion.questionContent.filter { it["type"] == "blank" }
         return blankQuestionContent.withIndex().all { (index, content) ->
-            content["text"] == userAnswer[index]
+            content["text"] == userAnswer[index.toString()]
         }
     }
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/QuizResult.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/QuizResult.kt
@@ -13,9 +13,9 @@ data class QuizResult(
                 choiceQuestion = choiceQuestions[index],
                 userAnswer = userOmrAnswers,
                 isCorrect = when (userOmrAnswers) {
-                    is Int -> evaluateChoiceQuestion(index, userOmrAnswers)
+                    is Number -> evaluateChoiceQuestion(index, userOmrAnswers)
                     is Map<*, *> -> evaluateBlankQuestion(index, userOmrAnswers)
-                    else -> throw Exception("Invalid user answer type")
+                    else -> false
                 },
             )
         }
@@ -25,7 +25,7 @@ data class QuizResult(
 
     private fun evaluateChoiceQuestion(
         index: Int,
-        userAnswer: Int,
+        userAnswer: Number,
     ): Boolean = userAnswer == (choiceQuestions[index] as ChoiceQuestion).answer
 
     private fun evaluateBlankQuestion(

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/UserOmrCreationInfo.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/UserOmrCreationInfo.kt
@@ -3,5 +3,5 @@ package kr.boostcamp_2024.course.domain.model
 data class UserOmrCreationInfo(
     val userId: String,
     val quizId: String,
-    val answers: List<Int>,
+    val answers: List<Any>,
 )

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuestionRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuestionRepository.kt
@@ -19,5 +19,5 @@ interface QuestionRepository {
 
     suspend fun deleteQuestions(questionIds: List<String>): Result<Unit>
 
-    suspend fun updateCurrentSubmit(questionId: String, selectedIndex: Int): Result<Unit>
+    suspend fun updateCurrentSubmit(userId: String, questionId: String, userAnswer: Any?): Result<Unit>
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuizRepository.kt
@@ -26,6 +26,8 @@ interface QuizRepository {
 
     suspend fun setQuizFinished(quizId: String): Result<Unit>
 
+    suspend fun updateQuizCurrentQuestion(quizId: String, currentQuestion: Int): Result<Unit>
+
     suspend fun startRealTimeQuiz(quizId: String): Result<Unit>
 
     suspend fun waitingRealTimeQuiz(quizId: String, waiting: Boolean, userId: String): Result<Unit>

--- a/core/domain/src/test/java/BlankQuestionQuizWithAnswerTest.kt
+++ b/core/domain/src/test/java/BlankQuestionQuizWithAnswerTest.kt
@@ -1,0 +1,55 @@
+import kr.boostcamp_2024.course.domain.model.BlankQuestionManager
+import org.junit.Before
+import org.junit.Test
+
+class BlankQuestionQuizWithAnswerTest {
+    private lateinit var blankQuestionWithAnswer: BlankQuestionManager
+
+    @Before
+    fun initBlankQuestionWithAnswer() {
+        blankQuestionWithAnswer = BlankQuestionManager { }
+        blankQuestionWithAnswer.setNewQuestions(
+            questionContents = listOf(
+                mapOf("type" to "text", "text" to "텍스트1"),
+                mapOf("type" to "blank", "text" to "낱말1"),
+                mapOf("type" to "text", "text" to "텍스트2"),
+                mapOf("type" to "blank", "text" to "낱말2"),
+            ),
+        )
+    }
+
+    @Test
+    fun `값이 null인 가장 작은 list index는 2이다`() {
+        val targetIdx = blankQuestionWithAnswer.getNullContentMinIndex()
+        assert(targetIdx == 1)
+    }
+
+    @Test
+    fun `낱말 추가`() {
+        val targetIdx = blankQuestionWithAnswer.getNullContentMinIndex()
+
+        blankQuestionWithAnswer.addBlankContent(0)
+        assert(blankQuestionWithAnswer.contents[targetIdx]?.get("index") == 0)
+        assert(blankQuestionWithAnswer.blankWords[0]["isUsed"] == true)
+    }
+
+    @Test
+    fun `낱말 제거`() {
+        val targetIdx = blankQuestionWithAnswer.getNullContentMinIndex()
+
+        blankQuestionWithAnswer.addBlankContent(0)
+        blankQuestionWithAnswer.removeBlankContent(targetIdx)
+
+        assert(blankQuestionWithAnswer.contents[targetIdx] == null)
+        assert(blankQuestionWithAnswer.blankWords[0]["isUsed"] == false)
+    }
+
+    @Test
+    fun `정답 가져오기`() {
+        blankQuestionWithAnswer.addBlankContent(0)
+
+        val answer = blankQuestionWithAnswer.getAnswer()
+        assert(answer.size == 2)
+        assert(answer["1"] == null)
+    }
+}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
@@ -20,6 +20,8 @@ import kr.boostcamp_2024.course.domain.model.BlankQuestion
 import kr.boostcamp_2024.course.domain.model.BlankQuestionManager
 import kr.boostcamp_2024.course.quiz.R
 
+private const val NULL_BLANK_TEXT = "_"
+
 @Composable
 fun BlankQuestionContent(
     isOwner: Boolean = false,
@@ -92,7 +94,7 @@ fun BlankQuestionContents(
             } else {
                 if (content == null) {
                     ConsumeBlankContentUi(
-                        word = "_",
+                        word = NULL_BLANK_TEXT,
                         onContentRemove = {},
                         onValueChanged = { _, _ -> },
                         removeIconVisible = false,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
@@ -1,0 +1,190 @@
+package kr.boostcamp_2024.course.quiz.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
+import kr.boostcamp_2024.course.domain.model.BlankQuestion
+import kr.boostcamp_2024.course.domain.model.BlankQuestionManager
+import kr.boostcamp_2024.course.quiz.R
+
+@Composable
+fun BlankQuestionContent(
+    isOwner: Boolean = false,
+    isRealTime: Boolean = false,
+    questionTitle: String,
+    contents: List<Map<String, Any>?>,
+    blankWords: List<Map<String, Any>>,
+    removeBlankWord: (Int) -> Unit,
+    addBlankWord: (Int) -> Unit,
+) {
+
+    Column(
+        modifier = Modifier.padding(vertical = 20.dp, horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        BlankQuestionTitle(title = questionTitle)
+        BlankQuestionContents(
+            isOwner = isOwner,
+            contents = contents,
+            onRemoveContentClick = removeBlankWord,
+        )
+        if (!isRealTime) {
+            Blanks(
+                words = blankWords,
+                onAddContentClick = addBlankWord,
+            )
+        }
+    }
+}
+
+@Composable
+fun BlankQuestionTitle(
+    title: String,
+) {
+    QuestionContentLabel(stringResource(R.string.txt_question_title))
+    QuestionTextBox(
+        text = title,
+        backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun BlankQuestionContents(
+    isOwner: Boolean,
+    contents: List<Map<String, Any>?>,
+    onRemoveContentClick: (Int) -> Unit,
+) {
+    QuestionContentLabel(stringResource(R.string.txt_question))
+
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(10.dp),
+            )
+            .padding(10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        contents.forEachIndexed { index, content ->
+            if (content?.get("type") == "text") {
+                ConsumeTextContentUi(
+                    word = content.getOrDefault("text", "") as String,
+                    onContentRemove = {},
+                    onValueChanged = {},
+                    removeIconInvisible = false,
+                    textFieldEnabled = false,
+                    clickableEnabled = false,
+                )
+            } else {
+                if (content == null) {
+                    ConsumeBlankContentUi(
+                        word = "_",
+                        onContentRemove = {},
+                        onValueChanged = {},
+                        removeIconVisible = false,
+                        textFieldEnabled = false,
+                        clickableEnabled = false,
+                    )
+                } else {
+                    ConsumeBlankContentUi(
+                        word = content.getOrDefault("text", "") as String,
+                        onContentRemove = {
+                            onRemoveContentClick(index)
+                        },
+                        onValueChanged = {},
+                        removeIconVisible = false,
+                        textFieldEnabled = false,
+                        clickableEnabled = !isOwner,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun Blanks(
+    words: List<Map<String, Any>>,
+    onAddContentClick: (Int) -> Unit,
+) {
+    QuestionContentLabel(stringResource(R.string.txt_blank))
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(10.dp),
+            )
+            .padding(10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        words.forEachIndexed { index, word ->
+            if (word["isUsed"] == false) {
+                ConsumeBlankContentUi(
+                    word = word["text"] as String,
+                    onContentRemove = {
+                        onAddContentClick(index)
+                    },
+                    onValueChanged = {},
+                    textFieldEnabled = false,
+                    removeIconVisible = false,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun QuestionContentLabel(
+    label: String,
+) {
+    Text(
+        label,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Preview
+@Composable
+private fun BlankQuestionContentPreview() {
+    val question = BlankQuestion(
+        id = "",
+        title = "제목",
+        solution = null,
+        questionContent = listOf(
+            mapOf("type" to "text", "text" to "우리는"),
+            mapOf("type" to "blank", "text" to "위키즈팀"),
+            mapOf("type" to "text", "text" to "입니다."),
+        ),
+        type = "blank",
+    )
+    val blankQuestionManager = BlankQuestionManager(question.questionContent)
+    WeQuizTheme {
+        BlankQuestionContent(
+            isOwner = true,
+            isRealTime = false,
+            contents = blankQuestionManager.contents,
+            questionTitle = question.title,
+            blankWords = blankQuestionManager.blankWords,
+            removeBlankWord = {},
+            addBlankWord = {},
+        )
+    }
+}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
@@ -173,6 +173,7 @@ private fun BlankQuestionContentPreview() {
             mapOf("type" to "text", "text" to "입니다."),
         ),
         type = "blank",
+        userAnswers = emptyList(),
     )
     val blankQuestionManager = BlankQuestionManager(
         updateCallback = {},

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContent.kt
@@ -30,7 +30,6 @@ fun BlankQuestionContent(
     removeBlankWord: (Int) -> Unit,
     addBlankWord: (Int) -> Unit,
 ) {
-
     Column(
         modifier = Modifier.padding(vertical = 20.dp, horizontal = 16.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -175,7 +174,10 @@ private fun BlankQuestionContentPreview() {
         ),
         type = "blank",
     )
-    val blankQuestionManager = BlankQuestionManager(question.questionContent)
+    val blankQuestionManager = BlankQuestionManager(
+        updateCallback = {},
+    )
+
     WeQuizTheme {
         BlankQuestionContent(
             isOwner = true,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.quiz.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,7 +12,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Cancel
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -35,34 +35,37 @@ fun ConsumeBlankContentUi(
     onValueChanged: (String) -> Unit,
     textFieldEnabled: Boolean = true,
 ) {
-    ElevatedCard(
-        modifier = Modifier.shadow(50.dp),
-        shape = RoundedCornerShape(4.dp),
-    ) {
-        Row(
-            modifier = Modifier
-                .padding(10.dp)
-                .clickable(
-                    enabled = true,
-                    onClick = onContentRemove,
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-
-            BasicTextField(
-                value = word,
-                onValueChange = onValueChanged,
-                modifier = Modifier.width(IntrinsicSize.Min),
-                enabled = textFieldEnabled,
+    Row(
+        modifier = Modifier
+            .shadow(
+                elevation = 10.dp,
+                shape = RoundedCornerShape(4.dp),
+                clip = false,
             )
-            if (removeIconInvisible) {
-                Icon(
-                    imageVector = Icons.Outlined.Cancel,
-                    contentDescription = stringResource(R.string.des_remove_blank),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            .background(
+                color = Color.White,
+                shape = RoundedCornerShape(4.dp),
+            )
+            .clickable(
+                onClick = onContentRemove,
+            )
+            .padding(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+
+        BasicTextField(
+            value = word,
+            onValueChange = onValueChanged,
+            modifier = Modifier.width(IntrinsicSize.Min),
+            enabled = textFieldEnabled,
+        )
+        if (removeIconInvisible) {
+            Icon(
+                imageVector = Icons.Outlined.Cancel,
+                contentDescription = stringResource(R.string.des_remove_blank),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
@@ -76,23 +79,22 @@ fun ConsumeTextContentUi(
     textFieldEnabled: Boolean = true,
 ) {
     Column(
-        modifier = Modifier.drawBehind {
-            val borderSize = 1.dp.toPx()
-            drawLine(
-                color = Color.Black,
-                start = Offset(0f, size.height),
-                end = Offset(size.width, size.height),
-                strokeWidth = borderSize,
-            )
-        },
+        modifier = Modifier
+            .drawBehind {
+                val borderSize = 1.dp.toPx()
+                drawLine(
+                    color = Color.Black,
+                    start = Offset(0f, size.height),
+                    end = Offset(size.width, size.height),
+                    strokeWidth = borderSize,
+                )
+            }
+            .clickable(
+                onClick = onContentRemove,
+            ),
     ) {
         Row(
-            modifier = Modifier
-                .padding(10.dp)
-                .clickable(
-                    enabled = true,
-                    onClick = onContentRemove,
-                ),
+            modifier = Modifier.padding(10.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -109,7 +111,6 @@ fun ConsumeTextContentUi(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-
         }
 
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
@@ -31,9 +31,10 @@ import kr.boostcamp_2024.course.quiz.R
 fun ConsumeBlankContentUi(
     word: String,
     onContentRemove: () -> Unit,
-    removeIconInvisible: Boolean = true,
+    removeIconVisible: Boolean = true,
     onValueChanged: (String) -> Unit,
     textFieldEnabled: Boolean = true,
+    clickableEnabled: Boolean = true,
 ) {
     Row(
         modifier = Modifier
@@ -47,6 +48,7 @@ fun ConsumeBlankContentUi(
                 shape = RoundedCornerShape(4.dp),
             )
             .clickable(
+                enabled = clickableEnabled,
                 onClick = onContentRemove,
             )
             .padding(10.dp),
@@ -60,7 +62,7 @@ fun ConsumeBlankContentUi(
             modifier = Modifier.width(IntrinsicSize.Min),
             enabled = textFieldEnabled,
         )
-        if (removeIconInvisible) {
+        if (removeIconVisible) {
             Icon(
                 imageVector = Icons.Outlined.Cancel,
                 contentDescription = stringResource(R.string.des_remove_blank),
@@ -77,6 +79,7 @@ fun ConsumeTextContentUi(
     removeIconInvisible: Boolean = true,
     onValueChanged: (String) -> Unit,
     textFieldEnabled: Boolean = true,
+    clickableEnabled: Boolean = true,
 ) {
     Column(
         modifier = Modifier
@@ -90,6 +93,7 @@ fun ConsumeTextContentUi(
                 )
             }
             .clickable(
+                enabled = clickableEnabled,
                 onClick = onContentRemove,
             ),
     ) {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/ChoiceQuestionContent.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/ChoiceQuestionContent.kt
@@ -1,0 +1,63 @@
+package kr.boostcamp_2024.course.quiz.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
+import kr.boostcamp_2024.course.domain.model.ChoiceQuestion
+
+@Composable
+fun ChoiceQuestionContent(
+    isOwner: Boolean = false,
+    isRealTime: Boolean = false,
+    question: ChoiceQuestion,
+    selectedIndex: Int,
+    onOptionSelected: (Int) -> Unit,
+) {
+    Column {
+        QuestionTitleAndDetail(
+            title = question.title,
+            description = question.description,
+        )
+
+        if (isRealTime) {
+            RealTimeQuestion(
+                isOwner = isOwner,
+                questions = question.choices,
+                selectedIndex = question.answer,
+            )
+        } else {
+            Question(
+                questions = question.choices,
+                selectedIndex = selectedIndex,
+                onOptionSelected = onOptionSelected,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ChoiceQuestionContentPreview() {
+    WeQuizTheme {
+        ChoiceQuestionContent(
+            question = ChoiceQuestion(
+                id = "",
+                title = "다음 중 가장 큰 수를 고르시오.",
+                description = "다음 중 가장 큰 수를 고르시오.",
+                solution = null,
+                choices = listOf(
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                ),
+                answer = 3,
+                userAnswers = listOf(),
+                type = "choice",
+            ),
+            selectedIndex = 0,
+            onOptionSelected = {},
+        )
+    }
+}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionConent.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionConent.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import kr.boostcamp_2024.course.domain.model.BlankQuestion
-import kr.boostcamp_2024.course.domain.model.BlankQuestionManager
 import kr.boostcamp_2024.course.domain.model.ChoiceQuestion
 import kr.boostcamp_2024.course.domain.model.Question
 import kr.boostcamp_2024.course.quiz.R
@@ -15,11 +14,16 @@ fun QuizContent(
     isOwner: Boolean = false,
     isRealTime: Boolean = false,
     currentPage: Int,
-    selectedIndexList: List<Int>,
+    selectedIndexList: List<Any?>,
     onOptionSelected: (Int, Int) -> Unit,
-    onBlanksSelected: (Map<Int, String?>) -> Unit,
+    onBlanksSelected: (Int, Map<String, String?>) -> Unit,
     questions: List<Question?>,
     showErrorMessage: (Int) -> Unit,
+    blankQuestionContents: List<Map<String, Any>?>,
+    blankWords: List<Map<String, Any>>,
+    removeBlankContent: (Int) -> Unit,
+    addBlankContent: (Int) -> Unit,
+    getBlankQuestionAnswer: () -> Map<String, String?>,
 ) {
     HorizontalPager(
         state = rememberPagerState(
@@ -34,30 +38,31 @@ fun QuizContent(
                     isOwner = isOwner,
                     isRealTime = isRealTime,
                     question = currentQuestion,
-                    selectedIndex = selectedIndexList[currentPage],
+                    selectedIndex = selectedIndexList[currentPage] as? Int ?: -1,
                     onOptionSelected = { newIndex ->
                         onOptionSelected(currentPage, newIndex)
                     },
                 )
             }
+
             is BlankQuestion -> {
-                val blankQuestionManager = BlankQuestionManager(currentQuestion.questionContent)
                 BlankQuestionContent(
                     isOwner = isOwner,
                     isRealTime = isRealTime,
-                    contents = blankQuestionManager.contents,
+                    contents = blankQuestionContents,
                     questionTitle = currentQuestion.title,
-                    blankWords = blankQuestionManager.blankWords,
+                    blankWords = blankWords,
                     removeBlankWord = { index ->
-                        blankQuestionManager.removeBlankContent(index)
-                        onBlanksSelected(blankQuestionManager.getAnswer())
+                        removeBlankContent(index)
+                        onBlanksSelected(currentPage, getBlankQuestionAnswer())
                     },
                     addBlankWord = { index ->
-                        blankQuestionManager.addBlankContent(index)
-                        onBlanksSelected(blankQuestionManager.getAnswer())
+                        addBlankContent(index)
+                        onBlanksSelected(currentPage, getBlankQuestionAnswer())
                     },
                 )
             }
+
             null -> {
                 Log.e("QuizContent", "Question is null")
                 showErrorMessage(R.string.err_load_questions)

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionConent.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionConent.kt
@@ -1,0 +1,67 @@
+package kr.boostcamp_2024.course.quiz.component
+
+import android.util.Log
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import kr.boostcamp_2024.course.domain.model.BlankQuestion
+import kr.boostcamp_2024.course.domain.model.BlankQuestionManager
+import kr.boostcamp_2024.course.domain.model.ChoiceQuestion
+import kr.boostcamp_2024.course.domain.model.Question
+import kr.boostcamp_2024.course.quiz.R
+
+@Composable
+fun QuizContent(
+    isOwner: Boolean = false,
+    isRealTime: Boolean = false,
+    currentPage: Int,
+    selectedIndexList: List<Int>,
+    onOptionSelected: (Int, Int) -> Unit,
+    onBlanksSelected: (Map<Int, String?>) -> Unit,
+    questions: List<Question?>,
+    showErrorMessage: (Int) -> Unit,
+) {
+    HorizontalPager(
+        state = rememberPagerState(
+            initialPage = currentPage,
+            pageCount = { questions.size },
+        ),
+        userScrollEnabled = false,
+    ) {
+        when (val currentQuestion = questions[currentPage]) {
+            is ChoiceQuestion -> {
+                ChoiceQuestionContent(
+                    isOwner = isOwner,
+                    isRealTime = isRealTime,
+                    question = currentQuestion,
+                    selectedIndex = selectedIndexList[currentPage],
+                    onOptionSelected = { newIndex ->
+                        onOptionSelected(currentPage, newIndex)
+                    },
+                )
+            }
+            is BlankQuestion -> {
+                val blankQuestionManager = BlankQuestionManager(currentQuestion.questionContent)
+                BlankQuestionContent(
+                    isOwner = isOwner,
+                    isRealTime = isRealTime,
+                    contents = blankQuestionManager.contents,
+                    questionTitle = currentQuestion.title,
+                    blankWords = blankQuestionManager.blankWords,
+                    removeBlankWord = { index ->
+                        blankQuestionManager.removeBlankContent(index)
+                        onBlanksSelected(blankQuestionManager.getAnswer())
+                    },
+                    addBlankWord = { index ->
+                        blankQuestionManager.addBlankContent(index)
+                        onBlanksSelected(blankQuestionManager.getAnswer())
+                    },
+                )
+            }
+            null -> {
+                Log.e("QuizContent", "Question is null")
+                showErrorMessage(R.string.err_load_questions)
+            }
+        }
+    }
+}

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionTextBox.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionTextBox.kt
@@ -2,6 +2,7 @@ package kr.boostcamp_2024.course.quiz.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -9,14 +10,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
 
 @Composable
-fun QuestionTextBox(text: String, modifier: Modifier = Modifier) {
+fun QuestionTextBox(
+    text: String,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+) {
     Box(
         modifier = modifier
+            .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant),
+            .background(backgroundColor),
     ) {
         Text(
             text = text,
@@ -28,5 +37,15 @@ fun QuestionTextBox(text: String, modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
+    }
+}
+
+@Preview
+@Composable
+fun QuestionTextBoxPreview() {
+    WeQuizTheme {
+        QuestionTextBox(
+            text = "다음 중 가장 큰 수를 고르시오.",
+        )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionTitleAndDetail.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuestionTitleAndDetail.kt
@@ -11,26 +11,35 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
 import kr.boostcamp_2024.course.quiz.R
 
 @Composable
 fun QuestionTitleAndDetail(title: String, description: String) {
     Column(
         verticalArrangement = Arrangement.spacedBy(10.dp),
-        modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 10.dp),
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 10.dp),
     ) {
         Text(
             stringResource(R.string.txt_question_title),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        QuestionTextBox(text = title)
+        QuestionTextBox(
+            text = title,
+            backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+        )
         Text(
             stringResource(R.string.txt_question_description),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        QuestionTextBox(text = description)
+        QuestionTextBox(
+            text = description,
+            backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+        )
         HorizontalDivider()
     }
 }
@@ -38,8 +47,10 @@ fun QuestionTitleAndDetail(title: String, description: String) {
 @Preview
 @Composable
 private fun QuestionTitleAndDetailPreview() {
-    QuestionTitleAndDetail(
-        "제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. ",
-        "제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. ",
-    )
+    WeQuizTheme {
+        QuestionTitleAndDetail(
+            "제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. ",
+            "제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. 제목 전체 다 보여줌. 줄 수 상관 없음. ",
+        )
+    }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
@@ -37,12 +35,10 @@ import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizBaseDialog
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizLocalRoundedImage
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizRightChatBubble
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
-import kr.boostcamp_2024.course.domain.model.ChoiceQuestion
 import kr.boostcamp_2024.course.domain.model.Question
 import kr.boostcamp_2024.course.quiz.R
-import kr.boostcamp_2024.course.quiz.component.Question
-import kr.boostcamp_2024.course.quiz.component.QuestionTitleAndDetail
 import kr.boostcamp_2024.course.quiz.component.QuestionTopBar
+import kr.boostcamp_2024.course.quiz.component.QuizContent
 import kr.boostcamp_2024.course.quiz.utils.timerFormat
 
 @Composable
@@ -51,13 +47,20 @@ fun GeneralQuestionScreen(
     currentPage: Int,
     choiceQuestions: List<Question>,
     countDownTime: Int,
-    selectedIndexList: List<Int>,
+    selectedIndexList: List<Any>,
     snackbarHostState: SnackbarHostState,
     onNavigationButtonClick: () -> Unit,
     onOptionSelected: (Int, Int) -> Unit,
+    onBlanksSelected: (Int, Map<String, String?>) -> Unit,
     onNextButtonClick: () -> Unit,
     onPreviousButtonClick: () -> Unit,
     onSubmitButtonClick: () -> Unit,
+    showErrorMessage: (Int) -> Unit,
+    blankQuestionContents: List<Map<String, Any>?>,
+    blankWords: List<Map<String, Any>>,
+    removeBlankContent: (Int) -> Unit,
+    addBlankContent: (Int) -> Unit,
+    getBlankQuestionAnswer: () -> Map<String, String?>,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -81,136 +84,162 @@ fun GeneralQuestionScreen(
                 .background(MaterialTheme.colorScheme.background)
                 .padding(innerPadding),
         ) {
+            LinearProgressIndicator(
+                progress = { (currentPage + 1) / choiceQuestions.size.toFloat() },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
             LazyColumn {
                 item {
-                    LinearProgressIndicator(
-                        progress = { (currentPage + 1) / choiceQuestions.size.toFloat() },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    GeneralQuizGuide(countDownTime = countDownTime)
                 }
-                item {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 20.dp, vertical = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
-                    ) {
-                        WeQuizRightChatBubble(
-                            modifier = Modifier.align(Alignment.CenterVertically),
-                            text = "${stringResource(R.string.txt_question_timer)} ${timerFormat(countDownTime)}",
-                        )
-                        WeQuizLocalRoundedImage(
-                            modifier = Modifier
-                                .size(120.dp)
-                                .align(Alignment.CenterVertically),
-                            imagePainter = painterResource(id = R.drawable.quiz_system_profile),
-                            contentDescription = stringResource(R.string.des_image_question),
-                        )
-                    }
-                }
-                item {
-                    HorizontalPager(
-                        state = rememberPagerState(
-                            initialPage = currentPage,
-                            pageCount = { choiceQuestions.size },
-                        ),
-                        userScrollEnabled = false,
-                    ) {
-                        val currentQuestion = choiceQuestions[currentPage]
-                        if (currentQuestion is ChoiceQuestion) {
-                            Column {
-                                QuestionTitleAndDetail(
-                                    title = currentQuestion.title,
-                                    description = currentQuestion.description,
-                                )
 
-                                Question(
-                                    questions = currentQuestion.choices,
-                                    selectedIndex = selectedIndexList[currentPage],
-                                    onOptionSelected = { newIndex ->
-                                        onOptionSelected(currentPage, newIndex)
-                                    },
-                                )
-                            }
-                        }
-                        // TODO: Blank question 처리 해야 해요!!
-                    }
+                item {
+                    QuizContent(
+                        currentPage = currentPage,
+                        selectedIndexList = selectedIndexList,
+                        onOptionSelected = onOptionSelected,
+                        questions = choiceQuestions,
+                        showErrorMessage = showErrorMessage,
+                        onBlanksSelected = onBlanksSelected,
+                        blankQuestionContents = blankQuestionContents,
+                        blankWords = blankWords,
+                        removeBlankContent = removeBlankContent,
+                        addBlankContent = addBlankContent,
+                        getBlankQuestionAnswer = getBlankQuestionAnswer,
+                    )
                 }
             }
 
-            Column(
+            GeneralQuizButtons(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .background(Color.Transparent)
                     .fillMaxWidth()
                     .padding(10.dp),
-            ) {
-                Button(
-                    onClick = {
-                        if (currentPage < choiceQuestions.size - 1) {
-                            onNextButtonClick()
-                        } else {
-                            showDialog = true
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        text = if (currentPage == choiceQuestions.size - 1) {
-                            stringResource(R.string.txt_question_done)
-                        } else {
-                            stringResource(R.string.txt_question_next_question)
-                        },
-                    )
-                }
-                Button(
-                    onClick = {
-                        if (currentPage > 0) onPreviousButtonClick()
-                    },
-                    enabled = currentPage > 0,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 5.dp, bottom = 30.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary,
-                        disabledContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
-                        disabledContentColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5f),
-                    ),
-                ) {
-                    Text(text = stringResource(R.string.btn_prev_question))
-                }
-            }
+                nextButtonText = if (currentPage == choiceQuestions.size - 1) {
+                    stringResource(R.string.txt_question_done)
+                } else {
+                    stringResource(R.string.txt_question_next_question)
+                },
+                onNextButtonClick = {
+                    if (currentPage < choiceQuestions.size - 1) {
+                        onNextButtonClick()
+                    } else {
+                        showDialog = true
+                    }
+                },
+                onPrevButtonClick = {
+                    if (currentPage > 0) onPreviousButtonClick()
+                },
+                prevButtonEnabled = currentPage > 0,
+            )
         }
 
         if (showDialog) {
-            WeQuizBaseDialog(
-                title = if (currentPage == choiceQuestions.size - 1) {
-                    stringResource(R.string.dialog_submit_script)
-                } else {
-                    stringResource(R.string.dialog_exit_script)
-                },
-                confirmTitle = if (currentPage == choiceQuestions.size - 1) {
-                    stringResource(R.string.txt_question_submit)
-                } else {
-                    stringResource(R.string.txt_question_exit)
-                },
-                dismissTitle = stringResource(R.string.txt_question_cancel),
-                onConfirm = {
-                    showDialog = false
-                    if (currentPage == choiceQuestions.size - 1) {
-                        onSubmitButtonClick()
-                    } else {
-                        onNavigationButtonClick()
-                    }
-                },
-                onDismissRequest = { showDialog = false },
-                dialogImage = painterResource(id = R.drawable.quiz_system_profile),
-                content = { /* no-op */ },
+            GeneralQuizDialog(
+                currentPage = currentPage,
+                questions = choiceQuestions,
+                closeDialog = { showDialog = false },
+                onNavigationButtonClick = onNavigationButtonClick,
+                onSubmitButtonClick = onSubmitButtonClick,
             )
         }
     }
+}
+
+@Composable
+fun GeneralQuizGuide(
+    countDownTime: Int,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+    ) {
+        WeQuizRightChatBubble(
+            modifier = Modifier.align(Alignment.CenterVertically),
+            text = "${stringResource(R.string.txt_question_timer)} ${timerFormat(countDownTime)}",
+        )
+        WeQuizLocalRoundedImage(
+            modifier = Modifier
+                .size(120.dp)
+                .align(Alignment.CenterVertically),
+            imagePainter = painterResource(id = R.drawable.quiz_system_profile),
+            contentDescription = stringResource(R.string.des_image_question),
+        )
+    }
+}
+
+@Composable
+fun GeneralQuizButtons(
+    modifier: Modifier = Modifier,
+    nextButtonText: String,
+    onNextButtonClick: () -> Unit,
+    onPrevButtonClick: () -> Unit,
+    prevButtonEnabled: Boolean,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Button(
+            onClick = onNextButtonClick,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = nextButtonText)
+        }
+        Button(
+            onClick = onPrevButtonClick,
+            enabled = prevButtonEnabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 5.dp, bottom = 30.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                disabledContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                disabledContentColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5f),
+            ),
+        ) {
+            Text(text = stringResource(R.string.btn_prev_question))
+        }
+    }
+}
+
+@Composable
+fun GeneralQuizDialog(
+    currentPage: Int,
+    questions: List<Question>,
+    closeDialog: () -> Unit,
+    onNavigationButtonClick: () -> Unit,
+    onSubmitButtonClick: () -> Unit,
+) {
+    WeQuizBaseDialog(
+        title = if (currentPage == questions.size - 1) {
+            stringResource(R.string.dialog_submit_script)
+        } else {
+            stringResource(R.string.dialog_exit_script)
+        },
+        confirmTitle = if (currentPage == questions.size - 1) {
+            stringResource(R.string.txt_question_submit)
+        } else {
+            stringResource(R.string.txt_question_exit)
+        },
+        dismissTitle = stringResource(R.string.txt_question_cancel),
+        onConfirm = {
+            closeDialog()
+            if (currentPage == questions.size - 1) {
+                onSubmitButtonClick()
+            } else {
+                onNavigationButtonClick()
+            }
+        },
+        onDismissRequest = closeDialog,
+        dialogImage = painterResource(id = R.drawable.quiz_system_profile),
+        content = { /* no-op */ },
+    )
 }
 
 @Preview(showBackground = true)
@@ -229,6 +258,13 @@ fun GeneralQuestionScreenPreview() {
             onNextButtonClick = {},
             onPreviousButtonClick = {},
             onSubmitButtonClick = {},
+            showErrorMessage = {},
+            onBlanksSelected = { _, _ -> },
+            blankQuestionContents = emptyList(),
+            blankWords = emptyList(),
+            removeBlankContent = {},
+            addBlankContent = {},
+            getBlankQuestionAnswer = { emptyMap() },
         )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
@@ -145,31 +145,34 @@ fun OwnerQuestionScreen(
                 modifier = Modifier.fillMaxSize(),
             ) {
                 if (quiz != null && currentQuestion != null) {
-                    if (currentQuestion is ChoiceQuestion) {
-                        item {
-                            RealTimeQuizWithOwnerGuideContent(
-                                ownerName = ownerName,
-                                totalParticipants = quiz.waitingUsers.size,
-                                submittedParticipants = currentQuestion.userAnswers.sum(),
-                            )
-                        }
-                        item {
-                            QuizContent(
-                                isOwner = true,
-                                isRealTime = true,
-                                currentPage = currentPage,
-                                selectedIndexList = currentQuestion.userAnswers,
-                                onOptionSelected = { _, _ -> },
-                                questions = choiceQuestions,
-                                showErrorMessage = showErrorMessage,
-                                onBlanksSelected = { _, _ -> },
-                                blankQuestionContents = blankQuestionContents,
-                                blankWords = blankWords,
-                                removeBlankContent = removeBlankWord,
-                                addBlankContent = addBlankWord,
-                                getBlankQuestionAnswer = getBlankQuestionAnswer,
-                            )
-                        }
+                    val submittedParticipants = if (currentQuestion is ChoiceQuestion) {
+                        currentQuestion.userAnswers.sum()
+                    } else {
+                        currentQuestion.userAnswers.size
+                    }
+                    item {
+                        RealTimeQuizWithOwnerGuideContent(
+                            ownerName = ownerName,
+                            totalParticipants = quiz.waitingUsers.size,
+                            submittedParticipants = submittedParticipants,
+                        )
+                    }
+                    item {
+                        QuizContent(
+                            isOwner = true,
+                            isRealTime = true,
+                            currentPage = currentPage,
+                            selectedIndexList = currentQuestion.userAnswers,
+                            onOptionSelected = { _, _ -> },
+                            questions = choiceQuestions,
+                            showErrorMessage = showErrorMessage,
+                            onBlanksSelected = { _, _ -> },
+                            blankQuestionContents = blankQuestionContents,
+                            blankWords = blankWords,
+                            removeBlankContent = removeBlankWord,
+                            addBlankContent = addBlankWord,
+                            getBlankQuestionAnswer = getBlankQuestionAnswer,
+                        )
                     }
                 }
             }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
@@ -44,10 +42,9 @@ import kr.boostcamp_2024.course.domain.model.ChoiceQuestion
 import kr.boostcamp_2024.course.domain.model.Question
 import kr.boostcamp_2024.course.domain.model.RealTimeQuiz
 import kr.boostcamp_2024.course.quiz.R
-import kr.boostcamp_2024.course.quiz.component.QuestionTitleAndDetail
 import kr.boostcamp_2024.course.quiz.component.QuestionTopBar
+import kr.boostcamp_2024.course.quiz.component.QuizContent
 import kr.boostcamp_2024.course.quiz.component.QuizOwnerDialog
-import kr.boostcamp_2024.course.quiz.component.RealTimeQuestion
 import kr.boostcamp_2024.course.quiz.viewmodel.OwnerQuestionViewModel
 
 @Composable
@@ -73,6 +70,12 @@ fun OwnerQuestionScreen(
         onNextButtonClick = questionViewModel::nextPage,
         onPreviousButtonClick = questionViewModel::previousPage,
         onQuizFinishButtonClick = questionViewModel::setQuizFinished,
+        showErrorMessage = questionViewModel::showErrorMessage,
+        blankQuestionContents = uiState.blankQuestionContents,
+        blankWords = uiState.blankWords,
+        removeBlankWord = questionViewModel.blankQuestionManager::removeBlankContent,
+        addBlankWord = questionViewModel.blankQuestionManager::addBlankContent,
+        getBlankQuestionAnswer = questionViewModel.blankQuestionManager::getAnswer,
     )
 
     if (uiState.isQuizFinished) {
@@ -98,6 +101,12 @@ fun OwnerQuestionScreen(
     onNextButtonClick: () -> Unit,
     onPreviousButtonClick: () -> Unit,
     onQuizFinishButtonClick: () -> Unit,
+    showErrorMessage: (Int) -> Unit,
+    blankQuestionContents: List<Map<String, Any>?>,
+    blankWords: List<Map<String, Any>>,
+    removeBlankWord: (Int) -> Unit,
+    addBlankWord: (Int) -> Unit,
+    getBlankQuestionAnswer: () -> Map<String, String?>,
 ) {
     var showQuitQuizDialog by rememberSaveable { mutableStateOf(false) }
     var showFinishQuizDialog by rememberSaveable { mutableStateOf(false) }
@@ -145,29 +154,23 @@ fun OwnerQuestionScreen(
                             )
                         }
                         item {
-                            HorizontalPager(
-                                state = rememberPagerState(
-                                    initialPage = currentPage,
-                                    pageCount = { choiceQuestions.size },
-                                ),
-                                userScrollEnabled = false,
-                            ) {
-                                Column {
-                                    QuestionTitleAndDetail(
-                                        title = currentQuestion.title,
-                                        description = currentQuestion.description,
-                                    )
-
-                                    RealTimeQuestion(
-                                        isOwner = true,
-                                        questions = currentQuestion.choices,
-                                        selectedIndex = currentQuestion.answer,
-                                    )
-                                }
-                            }
+                            QuizContent(
+                                isOwner = true,
+                                isRealTime = true,
+                                currentPage = currentPage,
+                                selectedIndexList = currentQuestion.userAnswers,
+                                onOptionSelected = { _, _ -> },
+                                questions = choiceQuestions,
+                                showErrorMessage = showErrorMessage,
+                                onBlanksSelected = { _, _ -> },
+                                blankQuestionContents = blankQuestionContents,
+                                blankWords = blankWords,
+                                removeBlankContent = removeBlankWord,
+                                addBlankContent = addBlankWord,
+                                getBlankQuestionAnswer = getBlankQuestionAnswer,
+                            )
                         }
                     }
-                    // todo: blank question 처리 해야 해요!!
                 }
             }
 

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
@@ -64,7 +64,7 @@ fun OwnerQuestionScreen(
     OwnerQuestionScreen(
         quiz = uiState.quiz,
         currentPage = uiState.currentPage,
-        choiceQuestions = uiState.choiceQuestions,
+        choiceQuestions = uiState.questions,
         ownerName = uiState.ownerName ?: "",
         snackbarHostState = snackbarHostState,
         onNextButtonClick = questionViewModel::nextPage,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionDetailScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionDetailScreen.kt
@@ -144,6 +144,7 @@ fun QuestionDetailScreenPreview() {
                 questionContent = emptyList(),
                 solution = "문제 해설",
                 type = "blank",
+                userAnswers = emptyList(),
             ),
             errorMessage = null,
             userAnswer = listOf(0, 0, 0, 0),

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
@@ -52,7 +52,13 @@ fun QuestionScreen(
             onPreviousButtonClick = questionViewModel::previousPage,
             onSubmitButtonClick = questionViewModel::submitAnswers,
             onNavigationButtonClick = onNavigationButtonClick,
-            showErrorMessage = questionViewModel::shownErrorMessage,
+            showErrorMessage = questionViewModel::showErrorMessage,
+            onBlanksSelected = questionViewModel::selectBlanks,
+            blankQuestionContents = uiState.blankQuestionContents,
+            blankWords = uiState.blankWords,
+            removeBlankContent = questionViewModel.blankQuestionManager::removeBlankContent,
+            addBlankContent = questionViewModel.blankQuestionManager::addBlankContent,
+            getBlankQuestionAnswer = questionViewModel.blankQuestionManager::getAnswer,
         )
     }
 

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
@@ -43,7 +43,7 @@ fun QuestionScreen(
         GeneralQuestionScreen(
             quiz = uiState.quiz,
             currentPage = uiState.currentPage,
-            questions = uiState.choiceQuestions,
+            questions = uiState.questions,
             countDownTime = uiState.countDownTime,
             selectedIndexList = uiState.selectedIndexList,
             snackbarHostState = snackbarHostState,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
@@ -52,6 +52,7 @@ fun QuestionScreen(
             onPreviousButtonClick = questionViewModel::previousPage,
             onSubmitButtonClick = questionViewModel::submitAnswers,
             onNavigationButtonClick = onNavigationButtonClick,
+            showErrorMessage = questionViewModel::shownErrorMessage,
         )
     }
 

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
@@ -49,7 +49,7 @@ fun UserQuestionScreen(
     UserQuestionScreen(
         quiz = uiState.quiz,
         currentPage = uiState.currentPage,
-        choiceQuestions = uiState.choiceQuestions,
+        choiceQuestions = uiState.questions,
         quizFinishDialog = quizFinishDialog,
         onQuizFinishDialogDismissButtonClick = { quizFinishDialog = false },
         selectedIndexList = uiState.selectedIndexList,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/OwnerQuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/OwnerQuestionViewModel.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 
 data class RealTimeWithOwnerQuestionUiState(
     val quiz: RealTimeQuiz? = null,
-    val choiceQuestions: List<Question?> = emptyList(),
+    val questions: List<Question?> = emptyList(),
     val ownerName: String? = null,
     val currentPage: Int = 0,
     val isLoading: Boolean = false,
@@ -80,7 +80,7 @@ class OwnerQuestionViewModel @Inject constructor(
             _uiState.update { currentState ->
                 currentState.copy(
                     isLoading = true,
-                    choiceQuestions = List(questionIds.size) { null },
+                    questions = List(questionIds.size) { null },
                 )
             }
             questionRepository.getRealTimeQuestions(questionIds)
@@ -90,7 +90,7 @@ class OwnerQuestionViewModel @Inject constructor(
                             questionFlow.onEach { question ->
                                 _uiState.update { currentState ->
                                     currentState.copy(
-                                        choiceQuestions = currentState.choiceQuestions.toMutableList().apply {
+                                        questions = currentState.questions.toMutableList().apply {
                                             this[index] = question
                                         },
                                     )
@@ -168,7 +168,7 @@ class OwnerQuestionViewModel @Inject constructor(
     }
 
     private fun setNewBlankQuestionManager(pageIdx: Int) {
-        val currentQuestion = _uiState.value.choiceQuestions[pageIdx]
+        val currentQuestion = _uiState.value.questions[pageIdx]
         if (currentQuestion is BlankQuestion) {
             blankQuestionManager.setNewQuestions(
                 isOwner = true,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/OwnerQuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/OwnerQuestionViewModel.kt
@@ -124,7 +124,7 @@ class OwnerQuestionViewModel @Inject constructor(
         }
     }
 
-    private fun showErrorMessage(errorMessageId: Int?) {
+    fun showErrorMessage(errorMessageId: Int?) {
         _uiState.update { currentState ->
             currentState.copy(
                 errorMessageId = errorMessageId,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
@@ -27,7 +27,7 @@ import javax.inject.Inject
 
 data class QuestionUiState(
     val quiz: BaseQuiz? = null,
-    val choiceQuestions: List<Question> = emptyList(),
+    val questions: List<Question> = emptyList(),
     val isSubmitting: Boolean = false,
     val currentPage: Int = 0,
     val selectedIndexList: List<Any> = emptyList(),
@@ -108,7 +108,7 @@ class QuestionViewModel @Inject constructor(
                     }
                     _uiState.update { currentState ->
                         currentState.copy(
-                            choiceQuestions = questions,
+                            questions = questions,
                             selectedIndexList = baseSelectedList,
                             isLoading = false,
                         )
@@ -175,7 +175,7 @@ class QuestionViewModel @Inject constructor(
     }
 
     private fun setNewBlankQuestionManager(pageIdx: Int) {
-        val currentQuestion = _uiState.value.choiceQuestions[pageIdx]
+        val currentQuestion = _uiState.value.questions[pageIdx]
         if (currentQuestion is BlankQuestion) {
             blankQuestionManager.setNewQuestions(
                 questionContents = currentQuestion.questionContent,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
@@ -114,6 +114,12 @@ class QuestionViewModel @Inject constructor(
         }
     }
 
+    fun shownErrorMessage(errorMessageId: Int) {
+        _uiState.update { currentState ->
+            currentState.copy(errorMessageId = errorMessageId)
+        }
+    }
+
     fun shownErrorMessage() {
         _uiState.update { currentState ->
             currentState.copy(errorMessageId = null)

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
+import kr.boostcamp_2024.course.domain.model.BlankQuestion
+import kr.boostcamp_2024.course.domain.model.BlankQuestionManager
 import kr.boostcamp_2024.course.domain.model.Question
 import kr.boostcamp_2024.course.domain.model.UserOmrCreationInfo
 import kr.boostcamp_2024.course.domain.repository.AuthRepository
@@ -28,12 +30,14 @@ data class QuestionUiState(
     val choiceQuestions: List<Question> = emptyList(),
     val isSubmitting: Boolean = false,
     val currentPage: Int = 0,
-    val selectedIndexList: List<Int> = emptyList(),
+    val selectedIndexList: List<Any> = emptyList(),
     val countDownTime: Int = 20 * 60,
     val isLoading: Boolean = false,
     val errorMessageId: Int? = null,
     val currentUserId: String? = null,
     val userOmrId: String? = null,
+    val blankQuestionContents: List<Map<String, Any>?> = emptyList(),
+    val blankWords: List<Map<String, Any>> = emptyList(),
 )
 
 @HiltViewModel
@@ -48,6 +52,7 @@ class QuestionViewModel @Inject constructor(
 
     private val _uiState: MutableStateFlow<QuestionUiState> = MutableStateFlow(QuestionUiState())
     val uiState: StateFlow<QuestionUiState> = _uiState.asStateFlow()
+    val blankQuestionManager = BlankQuestionManager(::setNewBlankContents)
 
     init {
         initial()
@@ -114,7 +119,7 @@ class QuestionViewModel @Inject constructor(
         }
     }
 
-    fun shownErrorMessage(errorMessageId: Int) {
+    fun showErrorMessage(errorMessageId: Int) {
         _uiState.update { currentState ->
             currentState.copy(errorMessageId = errorMessageId)
         }
@@ -136,15 +141,48 @@ class QuestionViewModel @Inject constructor(
         }
     }
 
+    fun selectBlanks(pageIndex: Int, blanks: Map<String, String?>) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                selectedIndexList = currentState.selectedIndexList.toMutableList().apply {
+                    this[pageIndex] = blanks
+                },
+            )
+        }
+    }
+
     fun nextPage() {
         _uiState.update { currentState ->
-            currentState.copy(currentPage = currentState.currentPage + 1)
+            val newPage = currentState.currentPage + 1
+            setNewBlankQuestionManager(newPage)
+            currentState.copy(currentPage = newPage)
         }
     }
 
     fun previousPage() {
         _uiState.update { currentState ->
-            currentState.copy(currentPage = currentState.currentPage - 1)
+            val newPage = currentState.currentPage - 1
+            setNewBlankQuestionManager(newPage)
+            currentState.copy(currentPage = newPage)
+        }
+    }
+
+    private fun setNewBlankQuestionManager(pageIdx: Int) {
+        val currentQuestion = _uiState.value.choiceQuestions[pageIdx]
+        if (currentQuestion is BlankQuestion) {
+            blankQuestionManager.setNewQuestions(
+                questionContents = currentQuestion.questionContent,
+            )
+            setNewBlankContents()
+        }
+    }
+
+    private fun setNewBlankContents() {
+        _uiState.update {
+            it.copy(
+                blankQuestionContents = blankQuestionManager.contents,
+                blankWords = blankQuestionManager.blankWords,
+            )
         }
     }
 
@@ -167,7 +205,7 @@ class QuestionViewModel @Inject constructor(
                 val userOmrCreationInfo = UserOmrCreationInfo(
                     userId = userId,
                     quizId = quizId,
-                    answers = _uiState.value.selectedIndexList.map { it },
+                    answers = _uiState.value.selectedIndexList,
                 )
                 userOmrRepository.submitQuiz(userOmrCreationInfo)
                     .onSuccess { userOmrId ->

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
@@ -99,10 +99,17 @@ class QuestionViewModel @Inject constructor(
             }
             questionRepository.getQuestions(questionIds)
                 .onSuccess { questions ->
+                    val baseSelectedList = questions.map {
+                        if (it is BlankQuestion) {
+                            mapOf<Int, String?>()
+                        } else {
+                            -1
+                        }
+                    }
                     _uiState.update { currentState ->
                         currentState.copy(
                             choiceQuestions = questions,
-                            selectedIndexList = List(questions.size) { -1 },
+                            selectedIndexList = baseSelectedList,
                             isLoading = false,
                         )
                     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/UserQuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/UserQuestionViewModel.kt
@@ -1,4 +1,4 @@
-package kr.boostcamp_2024.course.quiz.presentation.viewmodel
+package kr.boostcamp_2024.course.quiz.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kr.boostcamp_2024.course.domain.model.BaseQuiz
+import kr.boostcamp_2024.course.domain.model.BlankQuestion
+import kr.boostcamp_2024.course.domain.model.BlankQuestionManager
 import kr.boostcamp_2024.course.domain.model.Question
 import kr.boostcamp_2024.course.domain.model.UserOmrCreationInfo
 import kr.boostcamp_2024.course.domain.repository.AuthRepository
@@ -25,14 +27,16 @@ data class UserQuestionUiState(
     val quiz: BaseQuiz? = null,
     val choiceQuestions: List<Question> = emptyList(),
     val currentPage: Int = 0,
-    val selectedIndexList: List<Int> = emptyList(),
-    val submittedIndexList: List<Int> = emptyList(),
+    val selectedIndexList: List<Any?> = emptyList(),
+    val submittedIndexList: List<Any?> = emptyList(),
     val isLoading: Boolean = false,
     val errorMessageId: Int? = null,
     val currentUserId: String? = null,
     val userOmrId: String? = null,
     val isSubmitted: Boolean = false,
     val isQuizFinished: Boolean = false,
+    val blankQuestionContents: List<Map<String, Any>?> = emptyList(),
+    val blankWords: List<Map<String, Any>> = emptyList(),
 )
 
 @HiltViewModel
@@ -44,13 +48,12 @@ class UserQuestionViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val quizId = savedStateHandle.toRoute<QuestionRoute>().quizId
-
     private val _uiState: MutableStateFlow<UserQuestionUiState> =
         MutableStateFlow(UserQuestionUiState())
+    val blankQuestionManager = BlankQuestionManager(::setNewBlankContents)
 
     init {
         initial()
-        updatePageAndSubmitByOwner()
     }
 
     val uiState: StateFlow<UserQuestionUiState> = _uiState
@@ -84,14 +87,23 @@ class UserQuestionViewModel @Inject constructor(
             }
             questionRepository.getQuestions(questionIds)
                 .onSuccess { questions ->
+                    val baseSelectedList = questions.map {
+                        if (it is BlankQuestion) {
+                            mapOf<Int, String?>()
+                        } else {
+                            -1
+                        }
+                    }
                     _uiState.update { currentState ->
+
                         currentState.copy(
                             choiceQuestions = questions,
-                            selectedIndexList = List(questions.size) { -1 },
-                            submittedIndexList = List(questions.size) { -1 },
+                            selectedIndexList = baseSelectedList,
+                            submittedIndexList = baseSelectedList,
                             isLoading = false,
                         )
                     }
+                    updatePageAndSubmitByOwner()
                 }
                 .onFailure {
                     Log.e("QuestionViewModel", "문제 로드 실패", it)
@@ -134,6 +146,16 @@ class UserQuestionViewModel @Inject constructor(
         }
     }
 
+    fun selectBlanks(pageIndex: Int, blanks: Map<String, String?>) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                selectedIndexList = currentState.selectedIndexList.toMutableList().apply {
+                    this[pageIndex] = blanks
+                },
+            )
+        }
+    }
+
     private fun updatePageAndSubmitByOwner() {
         viewModelScope.launch {
             quizRepository.observeRealTimeQuiz(quizId)
@@ -141,6 +163,7 @@ class UserQuestionViewModel @Inject constructor(
                     result
                         .onSuccess { quiz ->
                             _uiState.update {
+                                setNewBlankQuestionManager(quiz.currentQuestion)
                                 it.copy(
                                     currentPage = quiz.currentQuestion,
                                     isSubmitted = false,
@@ -155,9 +178,31 @@ class UserQuestionViewModel @Inject constructor(
         }
     }
 
+    private fun setNewBlankQuestionManager(pageIdx: Int) {
+        val currentQuestion = _uiState.value.choiceQuestions[pageIdx]
+        if (currentQuestion is BlankQuestion) {
+            blankQuestionManager.setNewQuestions(
+                questionContents = currentQuestion.questionContent,
+            )
+            setNewBlankContents()
+        }
+    }
+
+    private fun setNewBlankContents() {
+        _uiState.update {
+            it.copy(
+                blankQuestionContents = blankQuestionManager.contents,
+                blankWords = blankQuestionManager.blankWords,
+            )
+        }
+    }
+
     fun submitQuestion(questionId: String) {
+        val currentState = _uiState.value
+        val currentUser = currentState.currentUserId ?: return
         viewModelScope.launch {
             val result = questionRepository.updateCurrentSubmit(
+                currentUser,
                 questionId,
                 _uiState.value.selectedIndexList[_uiState.value.currentPage],
             )
@@ -176,33 +221,38 @@ class UserQuestionViewModel @Inject constructor(
 
     fun submitAnswers() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            _uiState.value.currentUserId?.let { userId ->
-                val userOmrCreationInfo = UserOmrCreationInfo(
-                    userId = userId,
-                    quizId = quizId,
-                    answers = _uiState.value.submittedIndexList.map { it },
-                )
-                userOmrRepository.submitQuiz(userOmrCreationInfo)
-                    .onSuccess { userOmrId ->
-                        quizRepository.addUserOmrToQuiz(quizId, userOmrId)
-                            .onSuccess {
-                                _uiState.update {
-                                    it.copy(
-                                        userOmrId = userOmrId,
-                                        isLoading = false,
-                                    )
+            try {
+                _uiState.update { it.copy(isLoading = true) }
+                _uiState.value.currentUserId?.let { userId ->
+                    val userOmrCreationInfo = UserOmrCreationInfo(
+                        userId = userId,
+                        quizId = quizId,
+                        answers = _uiState.value.submittedIndexList as List<Any>,
+                    )
+                    userOmrRepository.submitQuiz(userOmrCreationInfo)
+                        .onSuccess { userOmrId ->
+                            quizRepository.addUserOmrToQuiz(quizId, userOmrId)
+                                .onSuccess {
+                                    _uiState.update {
+                                        it.copy(
+                                            userOmrId = userOmrId,
+                                            isLoading = false,
+                                        )
+                                    }
                                 }
-                            }
-                            .onFailure {
-                                Log.e("QuestionViewModel", "userOmrId 업데이트 실패", it)
-                                _uiState.update { it.copy(errorMessageId = R.string.err_answer_add) }
-                            }
-                    }
-                    .onFailure {
-                        Log.e("QuestionViewModel", "퀴즈 정답 제출 실패", it)
-                        _uiState.update { it.copy(errorMessageId = R.string.err_answer_add_quiz) }
-                    }
+                                .onFailure {
+                                    Log.e("QuestionViewModel", "userOmrId 업데이트 실패", it)
+                                    _uiState.update { it.copy(errorMessageId = R.string.err_answer_add) }
+                                }
+                        }
+                        .onFailure {
+                            Log.e("QuestionViewModel", "퀴즈 정답 제출 실패", it)
+                            _uiState.update { it.copy(errorMessageId = R.string.err_answer_add_quiz) }
+                        }
+                }
+            } catch (exception: Exception) {
+                Log.e("UserQuestionViewModel", "제출 실패 ", exception)
+                _uiState.update { it.copy(errorMessageId = R.string.err_answer_add_quiz) }
             }
         }
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/UserQuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/UserQuestionViewModel.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
 
 data class UserQuestionUiState(
     val quiz: BaseQuiz? = null,
-    val choiceQuestions: List<Question> = emptyList(),
+    val questions: List<Question> = emptyList(),
     val currentPage: Int = 0,
     val selectedIndexList: List<Any?> = emptyList(),
     val submittedIndexList: List<Any?> = emptyList(),
@@ -97,7 +97,7 @@ class UserQuestionViewModel @Inject constructor(
                     _uiState.update { currentState ->
 
                         currentState.copy(
-                            choiceQuestions = questions,
+                            questions = questions,
                             selectedIndexList = baseSelectedList,
                             submittedIndexList = baseSelectedList,
                             isLoading = false,
@@ -179,7 +179,7 @@ class UserQuestionViewModel @Inject constructor(
     }
 
     private fun setNewBlankQuestionManager(pageIdx: Int) {
-        val currentQuestion = _uiState.value.choiceQuestions[pageIdx]
+        val currentQuestion = _uiState.value.questions[pageIdx]
         if (currentQuestion is BlankQuestion) {
             blankQuestionManager.setNewQuestions(
                 questionContents = currentQuestion.questionContent,

--- a/feature/quiz/src/main/res/values/strings.xml
+++ b/feature/quiz/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="des_question_detail_top_app_bar_navigation_icon">뒤로 가기</string>
     <!-- error  -->
     <string name="err_load_quiz">퀴즈 로드에 실패했습니다.</string>
+    <string name="err_update_current_question">퀴즈 문제 현황 업데이트에 실패했습니다.</string>
     <string name="error_quiz_finished">퀴즈 종료에 실패했습니다.</string>
     <string name="err_load_questions">문제 로드에 실패했습니다.</string>
     <string name="err_answer_add">퀴즈에 응답 추가 실패했습니다.</string>

--- a/feature/quiz/src/main/res/values/strings.xml
+++ b/feature/quiz/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="txt_question_detail_solution">해설</string>
     <string name="txt_question_detail_title">제목</string>
     <string name="txt_question_title">제목</string>
+    <string name="txt_question">문제</string>
+    <string name="txt_blank">낱말</string>
     <string name="txt_question_description">설명</string>
     <string name="top_app_bar_question_title">퀴즈 제목</string>
     <string name="txt_question_done">완료</string>


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
✅ 퀴즈 진행 화면 작업
✅ 퀴즈 진행 기능 구현

### 📷 작업 결과
#### [일반 퀴즈]
https://github.com/user-attachments/assets/f10f7982-57ac-49e9-95a9-159194384973
#### [실시간 - 관리자]
https://github.com/user-attachments/assets/750aa0c6-e6c2-436d-9705-6500442622af
#### [실시간 - 참여자]
https://github.com/user-attachments/assets/9b594b69-ab64-47d0-912a-f74e10c51d43

### 🗣️ 공유할 내용

#### [question DB 구조 변경]
- 기존 1, 2, 3, 4번에 대한 제출 유저 수가 `userAnswers`에 기록이 되었다면 낱말에서는 userId가 리스트로 저장됩니다.
- 해당 내용을 적용해 기존 구현 부분 모두 수정 완료하였습니다.


|4지선다 문제|낱말 문제|
|:----:|:----:|
|<img width="415" alt="스크린샷 2024-11-27 오전 1 56 04" src="https://github.com/user-attachments/assets/eee1d53b-770c-4bdb-8a40-5000995a0e59">|<img width="419" alt="스크린샷 2024-11-27 오전 1 55 55" src="https://github.com/user-attachments/assets/4e99dd74-6523-41b4-8eea-911995e0613f">|

closed #143
closed #145