### PR TITLE
fix: 카테고리 생성 / 수정 오류 해결

### DIFF
--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
@@ -44,6 +44,7 @@ import kr.boostcamp_2024.course.category.R
 import kr.boostcamp_2024.course.category.viewModel.CreateCategoryViewModel
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizAsyncImage
+import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizCircularProgressIndicator
 import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizTextField
 import java.io.ByteArrayOutputStream
 
@@ -55,6 +56,10 @@ fun CreateCategoryScreen(
 ) {
     val uiState by viewModel.createCategoryUiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchCategoryInfo()
+    }
 
     LaunchedEffect(uiState) {
         if (uiState.creationSuccess) {
@@ -83,6 +88,7 @@ fun CreateCategoryScreen(
         onDescriptionChanged = viewModel::onDescriptionChanged,
         onNavigationButtonClick = onNavigationButtonClick,
         onCreateCategoryButtonClick = viewModel::uploadCategory,
+        isLoading = uiState.isLoading,
         guideText = guideText,
         onCurrentCategoryImageChanged = viewModel::onImageByteArrayChanged,
     )
@@ -101,6 +107,7 @@ fun CreateCategoryScreen(
     onDescriptionChanged: (String) -> Unit,
     onNavigationButtonClick: () -> Unit,
     onCreateCategoryButtonClick: () -> Unit,
+    isLoading: Boolean,
     guideText: String,
     onCurrentCategoryImageChanged: (ByteArray) -> Unit,
 ) {
@@ -184,6 +191,10 @@ fun CreateCategoryScreen(
                     Text(text = guideText)
                 }
             }
+        }
+
+        if (isLoading) {
+            WeQuizCircularProgressIndicator()
         }
     }
 }

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/viewmodel/CreateCategoryViewModel.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/viewmodel/CreateCategoryViewModel.kt
@@ -27,7 +27,7 @@ data class CreateCategoryUiState(
     val defaultImageUri: String? = null,
 ) {
     val isCategoryCreationValid: Boolean
-        get() = categoryName.isNotBlank()
+        get() = categoryName.isNotBlank() && isLoading.not()
 }
 
 @HiltViewModel

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/viewmodel/CreateCategoryViewModel.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/viewmodel/CreateCategoryViewModel.kt
@@ -97,7 +97,7 @@ class CreateCategoryViewModel @Inject constructor(
     private suspend fun updateCategory(categoryId: String) {
         val imageUrl = _createCategoryUiState.value.currentImage?.let { image ->
             storageRepository.uploadImage(image).getOrNull()
-        }
+        } ?: createCategoryUiState.value.defaultImageUri
 
         categoryRepository.updateCategory(
             categoryId,

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/viewmodel/CreateCategoryViewModel.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/viewmodel/CreateCategoryViewModel.kt
@@ -26,8 +26,7 @@ data class CreateCategoryUiState(
     val currentImage: ByteArray? = null,
     val defaultImageUri: String? = null,
 ) {
-    val isCategoryCreationValid: Boolean
-        get() = categoryName.isNotBlank() && isLoading.not()
+    val isCategoryCreationValid: Boolean = categoryName.isNotBlank() && isLoading.not()
 }
 
 @HiltViewModel


### PR DESCRIPTION
### 👩‍🌾 진행
✅ 카테고리 수정 시 기존 정보 가져오기 (카테고리 수정) 
✅ 카테고리 수정 시 로딩 처리 (카테고리 수정)
✅ 카테고리(퀴즈) 수정 시 (버튼을 여러번 누르면?) category_image_url가 반영되었다가 다시 null로 바뀜. → isLoading 중일 때 버튼 여러번 클릭 안되게 설정하기 (카테고리 수정)
✅ 카테고리 수정 시, 이미지 변경 하지 않을 경우 기존 이미지 반영

### 📷 작업 결과(사진)

https://github.com/user-attachments/assets/c22b0c09-4b2e-4c0a-992f-e3ad4d58c536

### 🗣️ 공유할 내용

x