### PR TITLE
fix: 퀴즈 진행 화면, 그룹원, 유저 생성 화면

### DIFF
--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/CustomNavType.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/CustomNavType.kt
@@ -19,7 +19,7 @@ object CustomNavType {
             Json.decodeFromString(Uri.decode(value))
 
         override fun serializeAsValue(value: UserUiModel?): String =
-            Uri.encode(Json.encodeToString(value))
+            Json.encodeToString(value)
 
         override fun put(bundle: Bundle, key: String, value: UserUiModel?) {
             bundle.putString(key, Json.encodeToString(value))

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/LoginNavigation.kt
@@ -1,14 +1,11 @@
 package kr.boostcamp_2024.course.login.navigation
 
-import android.os.Bundle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import kr.boostcamp_2024.course.login.model.UserUiModel
+import kr.boostcamp_2024.course.login.navigation.CustomNavType.UserUiModelType
 import kr.boostcamp_2024.course.login.presentation.LoginScreen
 import kr.boostcamp_2024.course.login.presentation.SignUpScreen
 import kotlin.reflect.typeOf
@@ -55,20 +52,5 @@ fun NavGraphBuilder.loginNavGraph(
             onSignUpSuccess = onSignUpSuccess,
             onNavigationButtonClick = onNavigationButtonClick,
         )
-    }
-}
-
-val UserUiModelType = object : NavType<UserUiModel?>(isNullableAllowed = true) {
-    override fun get(bundle: Bundle, key: String): UserUiModel? =
-        bundle.getString(key)?.let(Json::decodeFromString)
-
-    override fun parseValue(value: String): UserUiModel? =
-        if (value == "null") null else Json.decodeFromString(value)
-
-    override fun serializeAsValue(value: UserUiModel?): String =
-        if (value == null) "null" else Json.encodeToString(value)
-
-    override fun put(bundle: Bundle, key: String, value: UserUiModel?) {
-        bundle.putString(key, if (value == null) "null" else Json.encodeToString(value))
     }
 }

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -67,7 +68,6 @@ fun SignUpScreen(
     SignupScreen(
         uiState = uiState,
         snackBarHostState = snackBarHostState,
-        onEmailChanged = viewModel::onEmailChanged,
         onNameChanged = viewModel::onNameChanged,
         onProfileUriChanged = viewModel::onProfileUriChanged,
         onNavigationButtonClick = onNavigationButtonClick,
@@ -88,7 +88,6 @@ fun SignUpScreen(
 private fun SignupScreen(
     uiState: SignUpUiState,
     snackBarHostState: SnackbarHostState,
-    onEmailChanged: (String) -> Unit,
     onNameChanged: (String) -> Unit,
     onProfileUriChanged: (String) -> Unit,
     onNavigationButtonClick: () -> Unit,
@@ -135,10 +134,8 @@ private fun SignupScreen(
                     email = uiState.userSubmitInfo.email,
                     name = uiState.userSubmitInfo.name,
                     profileUri = uiState.userSubmitInfo.profileImageUrl,
-                    onEmailChanged = onEmailChanged,
                     onNameChanged = onNameChanged,
                     onProfileUriChanged = onProfileUriChanged,
-                    isEmailValid = uiState.isEmailValid,
                     setNewSnackBarMessage = setNewSnackBarMessage,
                 )
             }
@@ -161,10 +158,8 @@ fun SignUpContent(
     email: String,
     name: String,
     profileUri: String?,
-    onEmailChanged: (String) -> Unit,
     onNameChanged: (String) -> Unit,
     onProfileUriChanged: (String) -> Unit,
-    isEmailValid: Boolean,
     setNewSnackBarMessage: (Int) -> Unit,
 ) {
     val photoPickerLauncher = rememberLauncherForActivityResult(
@@ -200,12 +195,11 @@ fun SignUpContent(
             fallback = painterResource(kr.boostcamp_2024.course.designsystem.R.drawable.img_photo_picker),
         )
 
-        WeQuizTextField(
-            label = stringResource(R.string.txt_login_email_label),
-            text = email,
-            isError = isEmailValid.not(),
-            onTextChanged = onEmailChanged,
-            placeholder = stringResource(R.string.txt_login_email_placeholder),
+        TextField(
+            value = email,
+            onValueChange = {},
+            modifier = Modifier.fillMaxWidth(),
+            enabled = false,
         )
 
         WeQuizTextField(

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Log
-import android.util.Patterns
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -49,13 +48,8 @@ data class SignUpUiState(
     val isSubmitSuccess: Boolean = false,
     val snackBarMessage: Int? = null,
 ) {
-    val isEmailValid: Boolean = userSubmitInfo.email.isNotBlank() &&
-        Patterns.EMAIL_ADDRESS.matcher(userSubmitInfo.email)
-            .matches()
-
     val isSignUpButtonEnabled: Boolean = userSubmitInfo.email.isNotBlank() &&
-        userSubmitInfo.name.isNotBlank() &&
-        isEmailValid
+        userSubmitInfo.name.isNotBlank()
 }
 
 @HiltViewModel
@@ -118,14 +112,6 @@ class SignUpViewModel @Inject constructor(
                     Log.e("MainViewModel", "Failed to load user", it)
                 }
             }
-        }
-    }
-
-    fun onEmailChanged(email: String) {
-        _signUpUiState.update { currentState ->
-            currentState.copy(
-                userSubmitInfo = currentState.userSubmitInfo.copy(email = email),
-            )
         }
     }
 

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
@@ -9,6 +9,7 @@ import android.util.Patterns
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -20,18 +21,20 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import kr.boostcamp_2024.course.domain.model.UserSubmitInfo
 import kr.boostcamp_2024.course.domain.repository.AuthRepository
 import kr.boostcamp_2024.course.domain.repository.StorageRepository
 import kr.boostcamp_2024.course.domain.repository.UserRepository
 import kr.boostcamp_2024.course.login.R
 import kr.boostcamp_2024.course.login.model.UserUiModel
+import kr.boostcamp_2024.course.login.navigation.SignUpRoute
+import kr.boostcamp_2024.course.login.navigation.UserUiModelType
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import javax.inject.Inject
+import kotlin.reflect.typeOf
 
 data class SignUpUiState(
     val isLoading: Boolean = false,
@@ -46,14 +49,13 @@ data class SignUpUiState(
     val isSubmitSuccess: Boolean = false,
     val snackBarMessage: Int? = null,
 ) {
-    val isSignUpButtonEnabled: Boolean
-        get() = userSubmitInfo.email.isNotBlank() &&
-            userSubmitInfo.name.isNotBlank() &&
-            isEmailValid
-    val isEmailValid: Boolean
-        get() = userSubmitInfo.email.isNotBlank() &&
-            Patterns.EMAIL_ADDRESS.matcher(userSubmitInfo.email)
-                .matches()
+    val isEmailValid: Boolean = userSubmitInfo.email.isNotBlank() &&
+        Patterns.EMAIL_ADDRESS.matcher(userSubmitInfo.email)
+            .matches()
+
+    val isSignUpButtonEnabled: Boolean = userSubmitInfo.email.isNotBlank() &&
+        userSubmitInfo.name.isNotBlank() &&
+        isEmailValid
 }
 
 @HiltViewModel
@@ -64,22 +66,22 @@ class SignUpViewModel @Inject constructor(
     private val userRepository: UserRepository,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
-    private val userUiModel = savedStateHandle.get<String>("userUiModel?")?.let {
-        Json.decodeFromString(UserUiModel.serializer(), it)
-    }
-    private val userId: String? = savedStateHandle.get<String>("userId?")
+    private val userUiModel = savedStateHandle.toRoute<SignUpRoute>(mapOf(typeOf<UserUiModel?>() to UserUiModelType)).userUiModel
+    private val userId = savedStateHandle.toRoute<SignUpRoute>(mapOf(typeOf<UserUiModel?>() to UserUiModelType)).userId
+
     private val _signUpUiState: MutableStateFlow<SignUpUiState> = MutableStateFlow(SignUpUiState())
-    val signUpUiState: StateFlow<SignUpUiState> = _signUpUiState.onStart {
-        if (userId != null) {
-            loadUser()
-        } else {
-            setUserUiModel()
-        }
-    }.stateIn(
-        viewModelScope,
-        SharingStarted.WhileSubscribed(5000L),
-        SignUpUiState(),
-    )
+    val signUpUiState: StateFlow<SignUpUiState> = _signUpUiState
+        .onStart {
+            if (userId != null) {
+                loadUser()
+            } else {
+                setUserUiModel()
+            }
+        }.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000L),
+            SignUpUiState(),
+        )
 
     private fun setUserUiModel() {
         try {
@@ -87,8 +89,8 @@ class SignUpViewModel @Inject constructor(
                 it.copy(
                     userSubmitInfo = UserSubmitInfo(
                         email = requireNotNull(userUiModel?.email),
-                        name = requireNotNull(userUiModel?.name),
-                        profileImageUrl = userUiModel?.profileImageUrl,
+                        name = requireNotNull(userUiModel.name),
+                        profileImageUrl = userUiModel.profileImageUrl,
                     ),
                 )
             }
@@ -174,7 +176,7 @@ class SignUpViewModel @Inject constructor(
             )
             userRepository.addUser(requireNotNull(userUiModel?.id), userCreationInfo)
                 .onSuccess {
-                    saveUserKey(requireNotNull(userUiModel?.id))
+                    saveUserKey(requireNotNull(userUiModel.id))
                 }.onFailure {
                     Log.e("SignUpViewModel", "Failed to sign up", it)
                     setNewSnackBarMessage(R.string.error_sign_up)

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
@@ -26,8 +26,8 @@ import kr.boostcamp_2024.course.domain.repository.StorageRepository
 import kr.boostcamp_2024.course.domain.repository.UserRepository
 import kr.boostcamp_2024.course.login.R
 import kr.boostcamp_2024.course.login.model.UserUiModel
+import kr.boostcamp_2024.course.login.navigation.CustomNavType.UserUiModelType
 import kr.boostcamp_2024.course.login.navigation.SignUpRoute
-import kr.boostcamp_2024.course.login.navigation.UserUiModelType
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.HttpURLConnection

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.quiz.presentation.question
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -59,6 +60,10 @@ fun GeneralQuestionScreen(
     onSubmitButtonClick: () -> Unit,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
+
+    BackHandler {
+        showDialog = showDialog.not()
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
@@ -61,10 +61,10 @@ fun UserQuestionScreen(
         selectedIndexList = uiState.selectedIndexList,
         snackbarHostState = snackbarHostState,
         onOptionSelected = userQuestionViewModel::selectOption,
-        onNavigationButtonClick = onNavigationButtonClick,
         onSubmitButtonClick = userQuestionViewModel::submitQuestion,
         isSubmitted = uiState.isSubmitted,
         onQuizFinishButtonClick = userQuestionViewModel::submitAnswers,
+        onExitButtonClick = userQuestionViewModel::exitRealTimeQuiz,
     )
 
     uiState.errorMessageId?.let { errorMessageId ->
@@ -78,6 +78,12 @@ fun UserQuestionScreen(
     uiState.userOmrId?.let { userOmrId ->
         LaunchedEffect(userOmrId) {
             onQuizFinished(userOmrId, null)
+        }
+    }
+
+    LaunchedEffect(uiState.isExitSuccess) {
+        if (uiState.isExitSuccess) {
+            onNavigationButtonClick()
         }
     }
 
@@ -96,10 +102,10 @@ fun UserQuestionScreen(
     selectedIndexList: List<Int>,
     snackbarHostState: SnackbarHostState,
     onOptionSelected: (Int, Int) -> Unit,
-    onNavigationButtonClick: () -> Unit,
     onSubmitButtonClick: (String) -> Unit,
     isSubmitted: Boolean,
     onQuizFinishButtonClick: () -> Unit,
+    onExitButtonClick: () -> Unit,
 ) {
     var showExitDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -209,7 +215,7 @@ fun UserQuestionScreen(
             dismissTitle = stringResource(R.string.txt_question_cancel),
             onConfirm = {
                 showExitDialog = false
-                onNavigationButtonClick()
+                onExitButtonClick()
             },
             onDismissRequest = { showExitDialog = false },
             dialogImage = painterResource(id = R.drawable.quiz_system_profile),

--- a/feature/quiz/src/main/res/values/strings.xml
+++ b/feature/quiz/src/main/res/values/strings.xml
@@ -110,4 +110,5 @@
     <string name="err_load_current_page">페이지 로드에 실패하였습니다.</string>
     <string name="err_load_owner_name">관리자 이름을 가져오는데 실패했습니다.</string>
     <string name="err_submit_quetion">퀴즈 제출에 실패하였습니다.</string>
+    <string name="err_delete_waiting_user">실시간 퀴즈 나가기에 실패했습니다.</string>
 </resources>


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
✅ 실시간 퀴즈 진행 시 뒤로가기로 나갈 시 다시 돌아와지는 현상
✅ 일반 퀴즈 진행 시 뒤로가기 → 다이얼로그 처리
✅ 이미 가입한 그룹원에게 초대 가능
✅ 회원가입 이메일 수정 가능

### 📷 작업 결과(사진)

- 실시간 퀴즈 진행 시 뒤로가기로 나갈 시 다시 돌아와지는 현상

https://github.com/user-attachments/assets/48f7e6ae-da04-4166-84e6-1d44c1e4d677

- 일반 퀴즈 진행 시 뒤로가기 → 다이얼로그 처리

https://github.com/user-attachments/assets/d3fa2b30-7e88-487a-8437-7588f2213430

- 회원가입 이메일 수정 가능

https://github.com/user-attachments/assets/ceef488c-bb43-4d86-b00f-0bcfddac5993

### 🗣️ 공유할 내용
`SignUpRoute` Type-safe하게 개선하였습니다.
