### PR TITLE
fix: 스터디 생성 / 퀴즈 결과

### DIFF
--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuestionRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/QuestionRepository.kt
@@ -20,4 +20,5 @@ interface QuestionRepository {
     suspend fun deleteQuestions(questionIds: List<String>): Result<Unit>
 
     suspend fun updateCurrentSubmit(questionId: String, selectedIndex: Int): Result<Unit>
+
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/PieChartScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/PieChartScreen.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.quiz.presentation.question
 
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,6 +23,7 @@ import kr.boostcamp_2024.course.quiz.R
 
 @Composable
 fun PieChartScreen(userAnswers: List<Int>) {
+    Log.d("PieChartScreen", "userAnswers: $userAnswers")
     val totalInfo = mutableListOf<PieEntry>()
     val pieChartStrings: List<String> = listOf(
         stringResource(R.string.txt_label_pie_chart_1),
@@ -44,6 +46,12 @@ fun PieChartScreen(userAnswers: List<Int>) {
         }
         valueTextColor = Color.Black.toArgb()
         valueTextSize = 16f
+
+        valueFormatter = object : com.github.mikephil.charting.formatter.ValueFormatter() {
+            override fun getFormattedValue(value: Float): String {
+                return value.toInt().toString() // 정수로 변환하여 반환
+            }
+        }
     }
 
     val pieData = PieData(pieDataSet)

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/PieChartScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/PieChartScreen.kt
@@ -1,6 +1,5 @@
 package kr.boostcamp_2024.course.quiz.presentation.question
 
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,12 +17,12 @@ import com.github.mikephil.charting.charts.PieChart
 import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
 import com.github.mikephil.charting.data.PieEntry
+import com.github.mikephil.charting.formatter.ValueFormatter
 import com.github.mikephil.charting.utils.ColorTemplate.VORDIPLOM_COLORS
 import kr.boostcamp_2024.course.quiz.R
 
 @Composable
 fun PieChartScreen(userAnswers: List<Int>) {
-    Log.d("PieChartScreen", "userAnswers: $userAnswers")
     val totalInfo = mutableListOf<PieEntry>()
     val pieChartStrings: List<String> = listOf(
         stringResource(R.string.txt_label_pie_chart_1),
@@ -46,14 +45,12 @@ fun PieChartScreen(userAnswers: List<Int>) {
         }
         valueTextColor = Color.Black.toArgb()
         valueTextSize = 16f
-
-        valueFormatter = object : com.github.mikephil.charting.formatter.ValueFormatter() {
+        valueFormatter = object : ValueFormatter() {
             override fun getFormattedValue(value: Float): String {
-                return value.toInt().toString() // 정수로 변환하여 반환
+                return "${value.toInt()}"
             }
         }
     }
-
     val pieData = PieData(pieDataSet)
     Column(
         modifier = Modifier.fillMaxWidth(),

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
@@ -174,7 +174,7 @@ class QuestionViewModel @Inject constructor(
                                         }
                                         .onFailure {
                                             Log.e("QuestionViewModel", "user_answers 업데이트 실패")
-                                            _uiState.update { it.copy(isSubmitting = false, errorMessageId = R.string.err_user_answers_add) }
+                                            _uiState.update { it.copy(isSubmitting = false, errorMessageId = R.string.err_add_user_answers) }
                                         }
                                 }
                             }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/QuestionViewModel.kt
@@ -156,7 +156,6 @@ class QuestionViewModel @Inject constructor(
     fun submitAnswers() {
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true) }
-
             _uiState.value.currentUserId?.let { userId ->
                 val userOmrCreationInfo = UserOmrCreationInfo(
                     userId = userId,
@@ -167,7 +166,17 @@ class QuestionViewModel @Inject constructor(
                     .onSuccess { userOmrId ->
                         quizRepository.addUserOmrToQuiz(quizId, userOmrId)
                             .onSuccess {
-                                _uiState.update { it.copy(isSubmitting = true, userOmrId = userOmrId) }
+                                _uiState.update { it.copy(userOmrId = userOmrId) }
+                                _uiState.value.questions.forEachIndexed { index, question ->
+                                    questionRepository.updateCurrentSubmit(question.id, _uiState.value.selectedIndexList[index])
+                                        .onSuccess {
+                                            _uiState.update { it.copy(isSubmitting = true) }
+                                        }
+                                        .onFailure {
+                                            Log.e("QuestionViewModel", "user_answers 업데이트 실패")
+                                            _uiState.update { it.copy(isSubmitting = false, errorMessageId = R.string.err_user_answers_add) }
+                                        }
+                                }
                             }
                             .onFailure {
                                 Log.e("QuestionViewModel", "userOmrId 업데이트 실패", it)

--- a/feature/quiz/src/main/res/values/strings.xml
+++ b/feature/quiz/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="txt_edit_quiz_drop_down_menu_item">수정</string>
     <string name="txt_delete_quiz_drop_down_menu_item">퀴즈 제거</string>
     <string name="top_app_bar_edit_quiz">퀴즈 수정</string>
-    <string name="txt_pie_chart_center">결과 분석 결과</string>
+    <string name="txt_pie_chart_center">선택 통계</string>
     <string name="txt_quiz_statistics_dialog">퀴즈 결과 통계</string>
     <string name="btn_quiz_statistics_dialog_close">닫기</string>
     <string name="txt_label_pie_chart_1">1번</string>
@@ -110,4 +110,5 @@
     <string name="err_load_current_page">페이지 로드에 실패하였습니다.</string>
     <string name="err_load_owner_name">관리자 이름을 가져오는데 실패했습니다.</string>
     <string name="err_submit_quetion">퀴즈 제출에 실패하였습니다.</string>
+    <string name="err_user_answers_add">문제 통계 추가에 실패했습니다.</string>
 </resources>

--- a/feature/quiz/src/main/res/values/strings.xml
+++ b/feature/quiz/src/main/res/values/strings.xml
@@ -110,5 +110,5 @@
     <string name="err_load_current_page">페이지 로드에 실패하였습니다.</string>
     <string name="err_load_owner_name">관리자 이름을 가져오는데 실패했습니다.</string>
     <string name="err_submit_quetion">퀴즈 제출에 실패하였습니다.</string>
-    <string name="err_user_answers_add">문제 통계 추가에 실패했습니다.</string>
+    <string name="err_add_user_answers">문제 통계 추가에 실패했습니다.</string>
 </resources>

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
@@ -195,7 +195,9 @@ class CreateStudyViewModel @Inject constructor(
     }
 
     fun onMaxUserNumChange(groupMemberNumber: String) {
-        _uiState.update { it.copy(maxUserNum = groupMemberNumber) }
+        groupMemberNumber.toIntOrNull()?.takeIf { it in 2..50 }?.let {
+            _uiState.update { it.copy(maxUserNum = groupMemberNumber) }
+        }
     }
 
     fun onImageByteArrayChanged(imageByteArray: ByteArray) {

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/CreateStudyViewModel.kt
@@ -20,7 +20,6 @@ import kr.boostcamp_2024.course.domain.repository.StudyGroupRepository
 import kr.boostcamp_2024.course.domain.repository.UserRepository
 import kr.boostcamp_2024.course.study.navigation.CreateStudyRoute
 import javax.inject.Inject
-import kotlin.String
 
 data class CreateStudyUiState(
     val isLoading: Boolean = false,
@@ -195,7 +194,7 @@ class CreateStudyViewModel @Inject constructor(
     }
 
     fun onMaxUserNumChange(groupMemberNumber: String) {
-        groupMemberNumber.toIntOrNull()?.takeIf { it in 2..50 }?.let {
+        if (groupMemberNumber.isBlank() || groupMemberNumber.toIntOrNull() != null) {
             _uiState.update { it.copy(maxUserNum = groupMemberNumber) }
         }
     }


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
✅ 스터디 생성 시에 인원란에 숫자가 아닌 다른 값이 들어오면 앱이 종료되는 현상 해결
✅ 일반 퀴즈 결과 통계 그래프 띄우기

### 📷 작업 결과(사진)

[Screen_recording_20241127_212833.webm](https://github.com/user-attachments/assets/fae73c5f-ca5b-4cf4-ac0d-4ea5e5429725)

### 🗣️ 공유할 내용
인원 입력란에 숫자가 아닌 다른 문자가 포함되면 입력되지 않도록 수정했습니다.

일반 퀴즈 진행 시 `user_answers` 에 사용자 정답을 업데이트하도록 수정했습니다.
통계 다이얼로그에서 중앙의 문구와 선택한 사람의 숫자를 정수로 보여주도록 수정했습니다.
