### PR TITLE
fix: 알림 화면, 퀴즈 시작 화면

### DIFF
--- a/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/kr/boostcamp_2024/course/data/repository/StudyGroupRepositoryImpl.kt
@@ -15,23 +15,22 @@ class StudyGroupRepositoryImpl @Inject constructor(
 ) : StudyGroupRepository {
     private val studyGroupCollectionRef = firestore.collection("StudyGroup")
 
-    override suspend fun addStudyGroup(studyGroupCreationInfo: StudyGroupCreationInfo): Result<String> =
-        runCatching {
-            val request = StudyGroupDTO(
-                studyGroupImageUrl = studyGroupCreationInfo.studyGroupImageUrl,
-                name = studyGroupCreationInfo.name,
-                description = studyGroupCreationInfo.description,
-                maxUserNum = studyGroupCreationInfo.maxUserNum,
-                ownerId = studyGroupCreationInfo.ownerId,
-                users = listOf(studyGroupCreationInfo.ownerId),
-                categories = emptyList(),
-            )
-            val document = studyGroupCollectionRef.document()
-            document.set(request).await()
+    override suspend fun addStudyGroup(studyGroupCreationInfo: StudyGroupCreationInfo): Result<String> = runCatching {
+        val request = StudyGroupDTO(
+            studyGroupImageUrl = studyGroupCreationInfo.studyGroupImageUrl,
+            name = studyGroupCreationInfo.name,
+            description = studyGroupCreationInfo.description,
+            maxUserNum = studyGroupCreationInfo.maxUserNum,
+            ownerId = studyGroupCreationInfo.ownerId,
+            users = listOf(studyGroupCreationInfo.ownerId),
+            categories = emptyList(),
+        )
+        val document = studyGroupCollectionRef.document()
+        document.set(request).await()
 
-            val result = document.id
-            result
-        }
+        val result = document.id
+        result
+    }
 
     override suspend fun getStudyGroup(studyGroupId: String): Result<StudyGroup> = runCatching {
         val document = studyGroupCollectionRef.document(studyGroupId).get().await()
@@ -56,34 +55,35 @@ class StudyGroupRepositoryImpl @Inject constructor(
         studyGroupCollectionRef.document(studyGroupId).delete().await()
     }
 
-    override suspend fun deleteCategory(studyGroupId: String, categoryId: String): Result<Unit> =
-        runCatching {
-            val document = studyGroupCollectionRef.document(studyGroupId)
-            document.update("categories", FieldValue.arrayRemove(categoryId)).await()
-        }
+    override suspend fun deleteCategory(studyGroupId: String, categoryId: String): Result<Unit> = runCatching {
+        val document = studyGroupCollectionRef.document(studyGroupId)
+        document.update("categories", FieldValue.arrayRemove(categoryId)).await()
+    }
 
-    override suspend fun addCategoryToStudyGroup(studyGroupId: String, categoryId: String): Result<Unit> =
-        runCatching {
-            val document = studyGroupCollectionRef.document(studyGroupId)
-            document.update("categories", FieldValue.arrayUnion(categoryId)).await()
-        }
+    override suspend fun addCategoryToStudyGroup(studyGroupId: String, categoryId: String): Result<Unit> = runCatching {
+        val document = studyGroupCollectionRef.document(studyGroupId)
+        document.update("categories", FieldValue.arrayUnion(categoryId)).await()
+    }
 
-    override suspend fun getStudyGroupName(studyGroupId: String): Result<String> =
-        runCatching {
-            val document = studyGroupCollectionRef.document(studyGroupId).get().await()
-            val response = document.toObject(StudyGroupDTO::class.java)
-            val studyGroupName = requireNotNull(response?.name)
-            studyGroupName
-        }
+    override suspend fun getStudyGroupName(studyGroupId: String): Result<String> = runCatching {
+        val document = studyGroupCollectionRef.document(studyGroupId).get().await()
+        val response = document.toObject(StudyGroupDTO::class.java)
+        val studyGroupName = requireNotNull(response?.name)
+        studyGroupName
+    }
 
-    override suspend fun updateStudyGroup(studyGroupId: String, updatedInfo: StudyGroupUpdatedInfo): Result<Unit> =
-        runCatching {
-            val updatedInfoMap = hashMapOf<String, Any?>(
-                "study_group_image_url" to updatedInfo.studyGroupImageUrl,
-                "name" to updatedInfo.name,
-                "description" to updatedInfo.description,
-                "max_user_num" to updatedInfo.maxUserNum,
-            )
-            studyGroupCollectionRef.document(studyGroupId).update(updatedInfoMap).await()
-        }
+    override suspend fun updateStudyGroup(studyGroupId: String, updatedInfo: StudyGroupUpdatedInfo): Result<Unit> = runCatching {
+        val updatedInfoMap = hashMapOf<String, Any?>(
+            "study_group_image_url" to updatedInfo.studyGroupImageUrl,
+            "name" to updatedInfo.name,
+            "description" to updatedInfo.description,
+            "max_user_num" to updatedInfo.maxUserNum,
+        )
+        studyGroupCollectionRef.document(studyGroupId).update(updatedInfoMap).await()
+    }
+
+    override suspend fun addUser(studyGroupId: String, userId: String): Result<Unit> = runCatching {
+        val document = studyGroupCollectionRef.document(studyGroupId)
+        document.update("users", FieldValue.arrayUnion(userId)).await()
+    }
 }

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/NotificationWithGroupInfo.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/NotificationWithGroupInfo.kt
@@ -2,6 +2,6 @@ package kr.boostcamp_2024.course.domain.model
 
 data class NotificationWithGroupInfo(
     val notification: Notification,
-    val studyGroupName: String,
+    val studyGroupName: String?,
     val studyGroupImgUrl: String?,
 )

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/NotificationWithGroupInfo.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/model/NotificationWithGroupInfo.kt
@@ -3,4 +3,5 @@ package kr.boostcamp_2024.course.domain.model
 data class NotificationWithGroupInfo(
     val notification: Notification,
     val studyGroupName: String,
+    val studyGroupImgUrl: String?,
 )

--- a/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StudyGroupRepository.kt
+++ b/core/domain/src/main/java/kr/boostcamp_2024/course/domain/repository/StudyGroupRepository.kt
@@ -22,4 +22,6 @@ interface StudyGroupRepository {
     suspend fun deleteStudyGroup(studyGroupId: String): Result<Unit>
 
     suspend fun updateStudyGroup(studyGroupId: String, updateInfo: StudyGroupUpdatedInfo): Result<Unit>
+
+    suspend fun addUser(studyGroupId: String, userId: String): Result<Unit>
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/NotificationItem.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/NotificationItem.kt
@@ -37,11 +37,11 @@ fun NotificationItem(
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // todo: 이미지 넣을 때 추가 수정
         WeQuizAsyncImage(
             modifier = Modifier
-                .size(80.dp).clip(CircleShape),
-            imgUrl = null,
+                .size(80.dp)
+                .clip(CircleShape),
+            imgUrl = notificationInfo.studyGroupImgUrl,
             contentDescription = null,
         )
 

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/NotificationItem.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/NotificationItem.kt
@@ -50,7 +50,7 @@ fun NotificationItem(
                 .padding(start = 16.dp),
         ) {
             Text(
-                text = notificationInfo.studyGroupName,
+                text = notificationInfo.studyGroupName ?: "",
                 style = MaterialTheme.typography.labelMedium,
             )
             Text(

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/NotificationItem.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/component/NotificationItem.kt
@@ -66,7 +66,7 @@ fun NotificationItem(
             ) {
                 Button(
                     onClick = onRejectClick,
-                    modifier = Modifier.size(width = 53.dp, height = 24.dp),
+                    modifier = Modifier.height(24.dp),
                     contentPadding = PaddingValues(
                         start = 16.dp,
                         end = 16.dp,
@@ -84,7 +84,7 @@ fun NotificationItem(
 
                 Button(
                     onClick = onAcceptClick,
-                    modifier = Modifier.size(width = 53.dp, height = 24.dp),
+                    modifier = Modifier.height(24.dp),
                     contentPadding = PaddingValues(
                         start = 16.dp,
                         end = 16.dp,

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
@@ -71,6 +71,7 @@ fun NotificationScreen(
                 items = notificationInfos,
                 key = { it.notification.id },
             ) { notificationInfo ->
+                notificationInfo.studyGroupName ?: return@items
                 NotificationItem(
                     notificationInfo = notificationInfo,
                     onRejectClick = { onRejectClick(notificationInfo.notification.id) },

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
@@ -94,6 +94,7 @@ private fun NotificationScreenPreview() {
                         userid = "1",
                     ),
                     studyGroupName = "스터디 이름",
+                    studyGroupImgUrl = "null",
                 ),
             ),
             onRejectClick = {},

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/NotificationViewModel.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/NotificationViewModel.kt
@@ -103,11 +103,22 @@ class NotificationViewModel @Inject constructor(
             userRepository.addStudyGroupToUser(notification.userid, notification.groupId)
                 .onSuccess {
                     deleteInvitation(notification.id)
+                    addGroupMember(notification.userid, notification.groupId)
                 }
                 .onFailure { throwable ->
                     Log.e("NotificationViewModel", "실패: $throwable")
                     _uiState.update { it.copy(snackBarMessage = "알림 수락을 실패하였습니다.") }
                 }
+        }
+    }
+
+    private fun addGroupMember(userId: String, groupId: String) {
+        viewModelScope.launch {
+            studyGroupRepository.addUser(groupId, userId).onSuccess {
+            }.onFailure { throwable ->
+                Log.e("NotificationViewModel", "실패: $throwable")
+                _uiState.update { it.copy(snackBarMessage = "그룹원을 그룹에 추가하는데 실패하였습니다.") }
+            }
         }
     }
 

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/NotificationViewModel.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/NotificationViewModel.kt
@@ -61,7 +61,7 @@ class NotificationViewModel @Inject constructor(
                                 onFailure = {
                                     NotificationWithGroupInfo(
                                         notification = notification,
-                                        studyGroupName = "",
+                                        studyGroupName = null,
                                         studyGroupImgUrl = null,
                                     )
                                 },
@@ -127,8 +127,7 @@ class NotificationViewModel @Inject constructor(
 
     private fun addGroupMember(userId: String, groupId: String) {
         viewModelScope.launch {
-            studyGroupRepository.addUser(groupId, userId).onSuccess {
-            }.onFailure { throwable ->
+            studyGroupRepository.addUser(groupId, userId).onFailure { throwable ->
                 Log.e("NotificationViewModel", "실패: $throwable")
                 _uiState.update { it.copy(snackBarMessage = "그룹원을 그룹에 추가하는데 실패하였습니다.") }
             }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/NotificationViewModel.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/viewmodel/NotificationViewModel.kt
@@ -48,10 +48,24 @@ class NotificationViewModel @Inject constructor(
             authRepository.getUserKey().onSuccess { userKey ->
                 notificationRepository.getNotifications(userKey)
                     .onSuccess { notifications ->
-                        val notificationWithStudyGroupNameList = notifications.map {
-                            val studyGroupNameResult = studyGroupRepository.getStudyGroupName(it.groupId)
-                            val notificationWithGroupInfo =
-                                NotificationWithGroupInfo(it, studyGroupNameResult.getOrNull() ?: "")
+                        val notificationWithStudyGroupNameList = notifications.map { notification ->
+                            val studyGroupResult = studyGroupRepository.getStudyGroup(notification.groupId)
+                            val notificationWithGroupInfo = studyGroupResult.fold(
+                                onSuccess = { studyGroup ->
+                                    NotificationWithGroupInfo(
+                                        notification = notification,
+                                        studyGroupName = studyGroup.name,
+                                        studyGroupImgUrl = studyGroup.studyGroupImageUrl,
+                                    )
+                                },
+                                onFailure = {
+                                    NotificationWithGroupInfo(
+                                        notification = notification,
+                                        studyGroupName = "",
+                                        studyGroupImgUrl = null,
+                                    )
+                                },
+                            )
                             notificationWithGroupInfo
                         }
                         _uiState.update {
@@ -60,7 +74,6 @@ class NotificationViewModel @Inject constructor(
                                 notificationWithGroupInfoList = notificationWithStudyGroupNameList,
                             )
                         }
-
                     }
                     .onFailure {
                         _uiState.update {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -2,6 +2,8 @@ package kr.boostcamp_2024.course.quiz.component
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -25,9 +27,14 @@ fun QuizDataButton(
         when (quiz) {
             is Quiz -> {
                 Button(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth(),
                     onClick = { onCreateQuestionButtonClick(quiz.id) },
                     enabled = quiz.isOpened.not(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        disabledContainerColor = MaterialTheme.colorScheme.outlineVariant,
+                    ),
                 ) {
                     when (quiz.isOpened.not()) {
                         true -> Text(text = stringResource(R.string.txt_open_create_question))

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/QuizDataButton.kt
@@ -78,7 +78,7 @@ fun QuizDataButton(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = {
                         if (isStartRealTimeQuizEnabled) {
-                            onStartRealTimeQuizButtonClick
+                            onStartRealTimeQuizButtonClick()
                         } else if (isWaitingRealTimeQuizEnabled) {
                             onWaitingRealTimeQuizButtonClick(true)
                         }


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
✅ 그룹 초대 수작시 StudyGroup에 UserId 추가하기
✅ 알림 화면에 스터디 그룹 이미지 넣기
✅ 알림 화면 수락, 거절 버튼 크기 조정
✅ 퀴즈 화면 비활성화시 안보이는 Issue 해결
✅ 실시간 퀴즈 관리자 시작 버튼 버그 해결


### 📷 작업 결과(사진)
<img src= https://github.com/user-attachments/assets/37de7691-64f3-412e-81c4-ad8bf6f1a9ea width="250" >

### 🗣️ 공유할 내용
X
