### PR TITLE
refactor: 네트워크 통신 필요로 하는 버튼 multiple click 개선

### DIFF
--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
@@ -192,7 +192,7 @@ fun CreateCategoryScreen(
                 Button(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = onCreateCategoryButtonClick,
-                    enabled = isCategoryCreationValid,
+                    enabled = isCategoryCreationValid && !isLoading,
                 ) {
                     Text(text = guideText)
                 }

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
@@ -141,7 +141,7 @@ private fun SignupScreen(
             }
             item {
                 SignUpButtons(
-                    isSignUpValid = uiState.isSignUpButtonEnabled,
+                    isSignUpValid = uiState.isSignUpButtonEnabled && !uiState.isLoading,
                     onSubmitButtonClick = if (uiState.isEditMode) onEditButtonClick else onSignUpButtonClick,
                     isEditMode = uiState.isEditMode,
                 )

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/viewmodel/SignUpViewModel.kt
@@ -132,6 +132,7 @@ class SignUpViewModel @Inject constructor(
     }
 
     fun updateUser() {
+        setLoading(true)
         viewModelScope.launch {
             if (userId != null) {
                 val imageByteArray = withContext(Dispatchers.IO) {
@@ -145,13 +146,14 @@ class SignUpViewModel @Inject constructor(
                 )
                 userRepository.updateUser(userId, userCreationInfo).onSuccess {
                     _signUpUiState.update {
-                        it.copy(isSubmitSuccess = true)
+                        it.copy(
+                            isSubmitSuccess = true,
+                            isLoading = false,
+                        )
                     }
                 }.onFailure {
                     Log.e("MainViewModel", "Failed to update user")
-                    _signUpUiState.update {
-                        it.copy(isSubmitSuccess = false)
-                    }
+                    setLoading(false)
                 }
             }
         }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
@@ -238,7 +238,7 @@ fun CreateQuestionScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp),
-                            enabled = uiState.isCreateQuestionValid,
+                            enabled = uiState.isCreateQuestionValid && !uiState.isLoading,
                             onClick = onCreateQuestionButtonClick,
                         ) {
                             Text(
@@ -259,7 +259,7 @@ fun CreateQuestionScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp),
-                            enabled = uiState.isCreateBlankQuestionValid,
+                            enabled = uiState.isCreateBlankQuestionValid && !uiState.isLoading,
                             onClick = onCreateBlankQuestionButtonClick,
                         ) {
                             Text(

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
@@ -68,6 +68,7 @@ fun GeneralQuestionScreen(
     removeBlankContent: (Int) -> Unit,
     addBlankContent: (Int) -> Unit,
     getBlankQuestionAnswer: () -> Map<String, String?>,
+    isLoading: Boolean,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
     var buttonsHeight by remember { mutableStateOf(IntSize.Zero) }
@@ -149,6 +150,7 @@ fun GeneralQuestionScreen(
                 },
                 prevButtonEnabled = currentPage > 0,
                 setButtonsHeight = { buttonsHeight = it },
+                isNextButtonEnabled = !isLoading,
             )
         }
 
@@ -197,11 +199,13 @@ fun GeneralQuizButtons(
     onNextButtonClick: () -> Unit,
     onPrevButtonClick: () -> Unit,
     prevButtonEnabled: Boolean,
+    isNextButtonEnabled: Boolean,
 ) {
     Column(
         modifier = modifier.onGloballyPositioned { setButtonsHeight(it.size) },
     ) {
         Button(
+            enabled = isNextButtonEnabled,
             onClick = onNextButtonClick,
             modifier = Modifier.fillMaxWidth(),
         ) {
@@ -282,6 +286,7 @@ fun GeneralQuestionScreenPreview() {
             removeBlankContent = {},
             addBlankContent = {},
             getBlankQuestionAnswer = { emptyMap() },
+            isLoading = false,
         )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
@@ -68,6 +68,7 @@ fun OwnerQuestionScreen(
 
     OwnerQuestionScreen(
         quiz = uiState.quiz,
+        isNextButtonEnabled = !uiState.isQuizFinished,
         currentPage = uiState.currentPage,
         choiceQuestions = uiState.questions,
         ownerName = uiState.ownerName ?: "",
@@ -99,6 +100,7 @@ fun OwnerQuestionScreen(
 @Composable
 fun OwnerQuestionScreen(
     quiz: RealTimeQuiz?,
+    isNextButtonEnabled: Boolean,
     currentPage: Int,
     choiceQuestions: List<Question?>,
     ownerName: String,
@@ -209,6 +211,7 @@ fun OwnerQuestionScreen(
                     if (currentPage > 0) onPreviousButtonClick()
                 },
                 setButtonsHeight = { buttonsHeight = it },
+                isNextButtonEnabled = isNextButtonEnabled,
             )
         }
 
@@ -273,6 +276,7 @@ fun RealTimeQuizWithOwnerButtons(
     onNextButtonClick: () -> Unit,
     onPrevButtonClick: () -> Unit,
     setButtonsHeight: (IntSize) -> Unit,
+    isNextButtonEnabled: Boolean,
 ) {
     Column(
         modifier = modifier.onGloballyPositioned { setButtonsHeight(it.size) },
@@ -280,6 +284,7 @@ fun RealTimeQuizWithOwnerButtons(
         Button(
             onClick = onNextButtonClick,
             modifier = Modifier.fillMaxWidth(),
+            enabled = isNextButtonEnabled,
         ) {
             Text(
                 text = nextButtonText,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
@@ -60,6 +60,7 @@ fun QuestionScreen(
                 removeBlankContent = questionViewModel.blankQuestionManager::removeBlankContent,
                 addBlankContent = questionViewModel.blankQuestionManager::addBlankContent,
                 getBlankQuestionAnswer = questionViewModel.blankQuestionManager::getAnswer,
+                isLoading = uiState.isLoading,
             )
         }
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/CreateQuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/CreateQuizScreen.kt
@@ -69,7 +69,7 @@ fun CreateQuizScreen(
         quizDescription = uiState.value.quizDescription,
         quizDate = uiState.value.quizDate,
         quizSolveTime = uiState.value.quizSolveTime,
-        createQuizButtonEnabled = uiState.value.isCreateQuizButtonEnabled,
+        createQuizButtonEnabled = uiState.value.isCreateQuizButtonEnabled && !uiState.value.isLoading,
         isEditing = uiState.value.isEditing,
         selectedQuizTypeIndex = uiState.value.selectedQuizTypeIndex,
         snackBarHostState = snackBarHostState,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/CreateQuestionViewModel.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/viewmodel/CreateQuestionViewModel.kt
@@ -1,13 +1,11 @@
 package kr.boostcamp_2024.course.quiz.viewmodel
 
-import android.content.Context
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,7 +16,6 @@ import kr.boostcamp_2024.course.domain.model.ChoiceQuestionCreationInfo
 import kr.boostcamp_2024.course.domain.repository.AiRepository
 import kr.boostcamp_2024.course.domain.repository.QuestionRepository
 import kr.boostcamp_2024.course.domain.repository.QuizRepository
-import kr.boostcamp_2024.course.quiz.R
 import kr.boostcamp_2024.course.quiz.navigation.CreateQuestionRoute
 import javax.inject.Inject
 
@@ -76,7 +73,6 @@ class CreateQuestionViewModel @Inject constructor(
     private val questionRepository: QuestionRepository,
     private val quizRepository: QuizRepository,
     private val aiRepository: AiRepository,
-    @ApplicationContext private val context: Context,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val quizId: String = savedStateHandle.toRoute<CreateQuestionRoute>().quizId
@@ -211,7 +207,7 @@ class CreateQuestionViewModel @Inject constructor(
                         description = it.description,
                         solution = it.solution,
                         answer = getAnswerIndex(it.answer, it.choices),
-                        choices = List(4) { context.getString(R.string.txt_create_question_ai_choice_error) },
+                        choices = List(4) { "AI가 보기를 찾지 못했습니다." },
                     )
                 } else {
                     ChoiceQuestionCreationInfo(
@@ -231,9 +227,9 @@ class CreateQuestionViewModel @Inject constructor(
                     )
                 }
             }.onFailure {
-                setNewSnackBarMessage("AI 추천 문제 가져오기에 실패했습니다. 다시 시도해주세요!")
-                Log.d("CreateQuestionViewModel", "AI 추천 문제 가져오기 실패")
                 _createQuestionUiState.update { it.copy(isLoading = false) }
+                setNewSnackBarMessage("AI 추천 문제 가져오기에 실패했습니다. 다시 시도해주세요!")
+                Log.e("CreateQuestionViewModel", "AI 추천 문제 가져오기 실패")
             }
 
         }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -55,7 +55,7 @@ fun CreateStudyScreen(
         titleText = uiState.name,
         descriptionText = uiState.description,
         groupMemberNumber = uiState.maxUserNum,
-        canSubmitStudy = uiState.canSubmitStudy,
+        canSubmitStudy = uiState.canSubmitStudy && !uiState.isLoading,
         snackBarHostState = snackBarHostState,
         onNavigationButtonClick = onNavigationButtonClick,
         onTitleTextChange = viewmodel::onNameChanged,


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
> 네트워크 통신을 필요로 하는 버튼을 `loading 시, disabled 처리`하여 네트워크 요청이 여러 번 진행되는 문제를 해결하였습니다.
- ✅ 카테고리 생성 및 수정
- ✅ 스터디 생성 및 수정
- ✅ 퀴즈 생성 및 수정
- ✅ 문제 생성 및 수정
- ✅ 퀴즈 진행 완료
- ✅ 회원 가입 및 수정

### 📷 작업 결과
> 회원 정보 수정 과정을 대표 동영상으로 첨부합니다.

https://github.com/user-attachments/assets/c41db531-d859-4e00-811e-0815cc02f2b1

### 🗣️ 공유할 내용
####  회원 정보 수정 시, loadingIndicator 처리가 되지 않았던 부분 관련
- 관련 로직은 이미 구현되어 있었지만, 회원 정보 수정 시` is Loading`을 세팅하지 않아 발생한 문제였습니다. 따라서 별도의 브랜치를 파지 않고, 회원 정보 수정 시 isLoading을 true로 세팅해 줌으로써 해당 문제를 해결하였습니다.
