### PR TITLE
refactor: 문제 생성 페이지 ime padding 적용

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Wequiz">
+            android:theme="@style/Theme.Wequiz"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizChatBubble.kt
+++ b/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizChatBubble.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme

--- a/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizChatBubble.kt
+++ b/core/designsystem/src/main/java/kr/boostcamp_2024/course/designsystem/ui/theme/component/WeQuizChatBubble.kt
@@ -30,7 +30,6 @@ fun WeQuizChatBubble(
             text = text,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Bold,
         )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
@@ -65,25 +66,12 @@ fun ConsumeBlankContentUi(
             onValueChange = { newValue ->
                 onValueChanged(newValue, index)
             },
-            modifier = Modifier.width(IntrinsicSize.Min),
+            modifier = Modifier
+                .width(IntrinsicSize.Min)
+                .widthIn(min = 1.dp),
             enabled = textFieldEnabled,
-            decorationBox = { innerTextField ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (word.isEmpty()) {
-                        Text(
-                            text = "",
-                            modifier = Modifier.padding(start = 1.dp),
-                        )
-                    }
-                    Box(modifier = Modifier.weight(1f)) {
-                        innerTextField()
-                    }
-                }
-            },
-        )
+
+            )
         if (removeIconVisible) {
             Icon(
                 imageVector = Icons.Outlined.Cancel,
@@ -130,24 +118,10 @@ fun ConsumeTextContentUi(
                 onValueChange = { newValue ->
                     onValueChanged(newValue, index)
                 },
-                modifier = Modifier.width(IntrinsicSize.Min),
+                modifier = Modifier
+                    .width(IntrinsicSize.Min)
+                    .widthIn(1.dp),
                 enabled = textFieldEnabled,
-                decorationBox = { innerTextField ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        if (word.isEmpty()) {
-                            Text(
-                                text = "",
-                                modifier = Modifier.padding(start = 1.dp),
-                            )
-                        }
-                        Box(modifier = Modifier.weight(1f)) {
-                            innerTextField()
-                        }
-                    }
-                },
             )
 
             if (removeIconInvisible) {

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/component/BlankQuestionContentUi.kt
@@ -3,11 +3,9 @@ package kr.boostcamp_2024.course.quiz.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -17,7 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,8 +67,7 @@ fun ConsumeBlankContentUi(
                 .width(IntrinsicSize.Min)
                 .widthIn(min = 1.dp),
             enabled = textFieldEnabled,
-
-            )
+        )
         if (removeIconVisible) {
             Icon(
                 imageVector = Icons.Outlined.Cancel,

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
@@ -1,6 +1,5 @@
 package kr.boostcamp_2024.course.quiz.presentation.question
 
-import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -8,11 +7,8 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -183,7 +179,7 @@ fun CreateQuestionScreen(
                     top = innerPadding.calculateTopPadding(),
                     end = innerPadding.calculateEndPadding(LocalLayoutDirection.current),
                     bottom = if (isKeyboardVisible) keyboardHeight else innerPadding.calculateBottomPadding(),
-                )
+                ),
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
@@ -1,10 +1,18 @@
 package kr.boostcamp_2024.course.quiz.presentation.question
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -33,7 +41,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -161,10 +171,19 @@ fun CreateQuestionScreen(
             )
         },
     ) { innerPadding ->
+        val imeInsets = WindowInsets.ime
+        val density = LocalDensity.current
+        val keyboardHeight = with(density) { imeInsets.getBottom(density).toDp() }
+        val isKeyboardVisible = keyboardHeight > 0.dp
         Box(
             modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize(),
+                .fillMaxSize()
+                .padding(
+                    start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
+                    top = innerPadding.calculateTopPadding(),
+                    end = innerPadding.calculateEndPadding(LocalLayoutDirection.current),
+                    bottom = if (isKeyboardVisible) keyboardHeight else innerPadding.calculateBottomPadding(),
+                )
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
✅ basicTextField가 width에 따라 키보드에 가려지는 오류 수정 - 훈님
✅ CreateQuestionScreen imePadding 적용

### 📷 작업 결과(사진)

https://github.com/user-attachments/assets/23cfeaae-65c3-4a1d-a254-c960b8d91a42



### 🗣️ 공유할 내용

## basicTextField가 width에 따라 키보드에 가려지는 오류 수정
같은 ui의 작업이라 훈님이 진행하신 커밋을 함께 올렸습니다!

[basicTextField가 width에 따라 키보드에 가려지는 오류 수정 - 이훈](https://trite-ice-00b.notion.site/basicTextField-width-d42de55f70d8440cbae4492b0cd2584f)

## imePadding 적용
imePadding을 적용하기 위해 다음과 같이 modifier에 imePadding()을 사용했습니다:
```
Box(
            modifier = Modifier
                .fillMaxSize()
                .padding(innerPadding)
                .imePadding()
)
```
하지만 Scaffold의 innerPadding과 imePadding이 동시에 적용되면서 아래 영상처럼 BottomBar만큼의 여백이 생기는 현상이 있었습니다.

https://github.com/user-attachments/assets/111ceddb-1d43-4c51-99c6-11b83f7a7e46

이를 해결하기 위해 키보드가 화면에 나타나는지 여부를 판단하여,

키보드가 올라와 있으면 keyboardHeight를,
그렇지 않으면 innerPadding을 적용하는 방식으로 수정했습니다.
 

https://github.com/user-attachments/assets/db96ee75-d0f2-4cbc-b83d-480032865d5f

그런데 적용 후 확인해 보니, 키보드가 올라간 만큼 공백이 생기는 현상이 발생했습니다. 이를 해결하기 위해 AndroidManifest에 adjustResize 옵션을 추가하여 문제를 해결했습니다.

하지만 이 방식에 대해 추가적인 학습이 필요해 보입니다.

closed #189 
