### PR TITLE
refactor: snackbarhoststate hoisting 적용

### DIFF
--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizApp.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizApp.kt
@@ -1,15 +1,46 @@
 package kr.boostcamp_2024.course.wequiz.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.launch
 import kr.boostcamp_2024.course.designsystem.ui.theme.WeQuizTheme
+import kr.boostcamp_2024.course.wequiz.R
 
 @Composable
 fun WeQuizApp() {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    val localContextResource = LocalContext.current.resources
+    val onShowErrorSnackbar: (throwable: Throwable) -> Unit = { throwable ->
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(
+                message = throwable.message ?: localContextResource.getString(R.string.default_error_message),
+            )
+        }
+    }
+
     WeQuizTheme {
-        WeQuizNavHost(
-            modifier = Modifier.fillMaxSize(),
-        )
+        Box {
+            WeQuizNavHost(
+                modifier = Modifier
+                    .fillMaxSize(),
+                onShowErrorSnackbar = onShowErrorSnackbar,
+            )
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier
+                    .systemBarsPadding()
+                    .align(Alignment.BottomCenter),
+            )
+        }
     }
 }

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizApp.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizApp.kt
@@ -1,14 +1,10 @@
 package kr.boostcamp_2024.course.wequiz.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.launch
@@ -29,18 +25,11 @@ fun WeQuizApp() {
     }
 
     WeQuizTheme {
-        Box {
-            WeQuizNavHost(
-                modifier = Modifier
-                    .fillMaxSize(),
-                onShowErrorSnackbar = onShowErrorSnackbar,
-            )
-            SnackbarHost(
-                hostState = snackbarHostState,
-                modifier = Modifier
-                    .systemBarsPadding()
-                    .align(Alignment.BottomCenter),
-            )
-        }
+        WeQuizNavHost(
+            snackbarHostState = snackbarHostState,
+            modifier = Modifier
+                .fillMaxSize(),
+            onShowErrorSnackbar = onShowErrorSnackbar,
+        )
     }
 }

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.wequiz.ui
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
@@ -32,6 +33,7 @@ fun WeQuizNavHost(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
     startDestination: KClass<*> = LoginRoute::class,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     NavHost(
@@ -47,6 +49,7 @@ fun WeQuizNavHost(
             },
             onSignUp = navController::navigationSignUp,
             onSignUpSuccess = navController::navigateUp,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
@@ -58,6 +61,7 @@ fun WeQuizNavHost(
             onEditStudyButtonClick = navController::navigateCreateStudy,
             onEditUserClick = { userId -> navController.navigationSignUp(null, userId) },
             onLoginOutClick = navController::navigationLogin,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
@@ -69,6 +73,7 @@ fun WeQuizNavHost(
             onDeleteStudyGroupSuccess = navController::navigateUp,
             onLeaveStudyGroupSuccess = navController::navigateUp,
             onEditStudyGroupButtonClick = navController::navigateCreateStudy,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
@@ -78,6 +83,7 @@ fun WeQuizNavHost(
             onQuizClick = navController::navigateQuiz,
             onCreateCategorySuccess = navController::navigateUp,
             onCreateCategoryButtonClick = navController::navigateCreateCategory,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
@@ -92,6 +98,7 @@ fun WeQuizNavHost(
             onSettingMenuClick = navController::navigateCreateQuiz,
             onEditQuizSuccess = navController::navigateUp,
             onQuizDeleteSuccess = navController::navigateUp,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -47,6 +47,7 @@ fun WeQuizNavHost(
             },
             onSignUp = navController::navigationSignUp,
             onSignUpSuccess = navController::navigateUp,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
         mainNavGraph(
@@ -57,6 +58,7 @@ fun WeQuizNavHost(
             onEditStudyButtonClick = navController::navigateCreateStudy,
             onEditUserClick = { userId -> navController.navigationSignUp(null, userId) },
             onLoginOutClick = navController::navigationLogin,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
         studyNavGraph(
@@ -67,6 +69,7 @@ fun WeQuizNavHost(
             onDeleteStudyGroupSuccess = navController::navigateUp,
             onLeaveStudyGroupSuccess = navController::navigateUp,
             onEditStudyGroupButtonClick = navController::navigateCreateStudy,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
         categoryNavGraph(
@@ -75,6 +78,7 @@ fun WeQuizNavHost(
             onQuizClick = navController::navigateQuiz,
             onCreateCategorySuccess = navController::navigateUp,
             onCreateCategoryButtonClick = navController::navigateCreateCategory,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
 
         quizNavGraph(
@@ -88,6 +92,7 @@ fun WeQuizNavHost(
             onSettingMenuClick = navController::navigateCreateQuiz,
             onEditQuizSuccess = navController::navigateUp,
             onQuizDeleteSuccess = navController::navigateUp,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
+++ b/app/src/main/java/kr/boostcamp_2024/course/wequiz/ui/WeQuizNavHost.kt
@@ -32,6 +32,7 @@ fun WeQuizNavHost(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
     startDestination: KClass<*> = LoginRoute::class,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     NavHost(
         modifier = modifier,

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="default_error_message">오류가 발생했습니다.\n다시 시도해 주세요.</string>
+</resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="default_error_message">发生错误\n请重试。</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">wequiz</string>
+    <string name="default_error_message">An Error occured.\nPlease try again.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">wequiz</string>
+    <string name="app_name" translatable="false">wequiz</string>
     <string name="default_error_message">An Error occured.\nPlease try again.</string>
 </resources>

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/navigation/CategoryNavigation.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/navigation/CategoryNavigation.kt
@@ -36,6 +36,7 @@ fun NavGraphBuilder.categoryNavGraph(
     onQuizClick: (String, String) -> Unit,
     onCreateCategorySuccess: () -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<CategoryRoute> {
         CategoryScreen(
@@ -43,12 +44,14 @@ fun NavGraphBuilder.categoryNavGraph(
             onCreateQuizButtonClick = onCreateQuizButtonClick,
             onQuizClick = onQuizClick,
             onCreateCategoryButtonClick = onCreateCategoryButtonClick,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<CreateCategoryRoute> {
         CreateCategoryScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateCategorySuccess = onCreateCategorySuccess,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/navigation/CategoryNavigation.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/navigation/CategoryNavigation.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.category.navigation
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -36,6 +37,7 @@ fun NavGraphBuilder.categoryNavGraph(
     onQuizClick: (String, String) -> Unit,
     onCreateCategorySuccess: () -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<CategoryRoute> {
@@ -44,6 +46,7 @@ fun NavGraphBuilder.categoryNavGraph(
             onCreateQuizButtonClick = onCreateQuizButtonClick,
             onQuizClick = onQuizClick,
             onCreateCategoryButtonClick = onCreateCategoryButtonClick,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
@@ -51,6 +54,7 @@ fun NavGraphBuilder.categoryNavGraph(
         CreateCategoryScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateCategorySuccess = onCreateCategorySuccess,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CategoryScreen.kt
@@ -19,11 +19,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -50,6 +53,7 @@ internal fun CategoryScreen(
     onCreateQuizButtonClick: (String) -> Unit,
     onQuizClick: (String, String) -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     categoryViewModel: CategoryViewModel = hiltViewModel(),
 ) {
@@ -80,6 +84,7 @@ internal fun CategoryScreen(
         onQuizClick = onQuizClick,
         onCategoryDeleteClick = categoryViewModel::onCategoryDeleteClick,
         onCreateCategoryButtonClick = onCreateCategoryButtonClick,
+        snackbarHostState = snackbarHostState,
     )
 }
 
@@ -93,6 +98,7 @@ internal fun CategoryScreen(
     onQuizClick: (String, String) -> Unit,
     onCategoryDeleteClick: () -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val scrollBehavior =
         TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
@@ -148,6 +154,7 @@ internal fun CategoryScreen(
                 }
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         if (category != null) {
             Column(

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CategoryScreen.kt
@@ -19,13 +19,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -51,11 +49,11 @@ internal fun CategoryScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateQuizButtonClick: (String) -> Unit,
     onQuizClick: (String, String) -> Unit,
-    categoryViewModel: CategoryViewModel = hiltViewModel(),
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
+    categoryViewModel: CategoryViewModel = hiltViewModel(),
 ) {
     val categoryUiState = categoryViewModel.categoryUiState.collectAsStateWithLifecycle()
-    val snackBarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         categoryViewModel.initViewmodel()
@@ -63,7 +61,7 @@ internal fun CategoryScreen(
 
     LaunchedEffect(categoryUiState.value.snackBarMessage) {
         categoryUiState.value.snackBarMessage?.let { message ->
-            snackBarHostState.showSnackbar(message)
+            onShowErrorSnackbar(Exception(message))
             categoryViewModel.setNewSnackBarMessage(null)
         }
     }

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
@@ -17,8 +17,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -43,10 +41,10 @@ import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizValidateTe
 internal fun CreateCategoryScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateCategorySuccess: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: CreateCategoryViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.createCategoryUiState.collectAsStateWithLifecycle()
-    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.fetchCategoryInfo()
@@ -57,7 +55,7 @@ internal fun CreateCategoryScreen(
             onCreateCategorySuccess()
         }
         uiState.errorMessage?.let { message ->
-            snackbarHostState.showSnackbar(message)
+            onShowErrorSnackbar(Exception(message))
             viewModel.setErrorMessage(null)
         }
     }
@@ -79,7 +77,6 @@ internal fun CreateCategoryScreen(
         currentCategoryImage = uiState.currentImage,
         defaultCategoryImageUri = uiState.defaultImageUri,
         isCategoryCreationValid = uiState.isCategoryCreationValid,
-        snackbarHostState = snackbarHostState,
         onNameChanged = viewModel::onNameChanged,
         onDescriptionChanged = viewModel::onDescriptionChanged,
         onNavigationButtonClick = onNavigationButtonClick,
@@ -98,7 +95,6 @@ internal fun CreateCategoryScreen(
     currentCategoryImage: ByteArray?,
     defaultCategoryImageUri: String?,
     isCategoryCreationValid: Boolean,
-    snackbarHostState: SnackbarHostState,
     onNameChanged: (String) -> Unit,
     onDescriptionChanged: (String) -> Unit,
     onNavigationButtonClick: () -> Unit,
@@ -122,9 +118,6 @@ internal fun CreateCategoryScreen(
                     }
                 },
             )
-        },
-        snackbarHost = {
-            SnackbarHost(snackbarHostState)
         },
     ) { innerPadding ->
         Column(
@@ -190,7 +183,6 @@ private fun CreateCategoryScreenPreview() {
             currentCategoryImage = null,
             defaultCategoryImageUri = null,
             isCategoryCreationValid = true,
-            snackbarHostState = SnackbarHostState(),
             onNameChanged = {},
             onDescriptionChanged = {},
             onNavigationButtonClick = {},

--- a/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
+++ b/feature/category/src/main/java/kr/boostcamp_2024/course/category/presentation/CreateCategoryScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -41,6 +43,7 @@ import kr.boostcamp_2024.course.designsystem.ui.theme.component.WeQuizValidateTe
 internal fun CreateCategoryScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateCategorySuccess: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: CreateCategoryViewModel = hiltViewModel(),
 ) {
@@ -84,6 +87,7 @@ internal fun CreateCategoryScreen(
         isLoading = uiState.isLoading,
         guideText = stringResource(guideText),
         onCurrentCategoryImageChanged = viewModel::onImageByteArrayChanged,
+        snackbarHostState = snackbarHostState,
     )
 }
 
@@ -102,6 +106,7 @@ internal fun CreateCategoryScreen(
     isLoading: Boolean,
     guideText: String,
     onCurrentCategoryImageChanged: (ByteArray) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         topBar = {
@@ -119,6 +124,7 @@ internal fun CreateCategoryScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/LoginNavigation.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.login.navigation
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -43,12 +44,14 @@ fun NavGraphBuilder.loginNavGraph(
     onLoginSuccess: () -> Unit,
     onSignUp: (UserUiModel) -> Unit,
     onSignUpSuccess: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<LoginRoute> {
         LoginScreen(
             onLoginSuccess = onLoginSuccess,
             onSignUp = onSignUp,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
@@ -59,6 +62,7 @@ fun NavGraphBuilder.loginNavGraph(
         SignUpScreen(
             onSignUpSuccess = onSignUpSuccess,
             onNavigationButtonClick = onNavigationButtonClick,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/navigation/LoginNavigation.kt
@@ -43,11 +43,13 @@ fun NavGraphBuilder.loginNavGraph(
     onLoginSuccess: () -> Unit,
     onSignUp: (UserUiModel) -> Unit,
     onSignUpSuccess: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<LoginRoute> {
         LoginScreen(
             onLoginSuccess = onLoginSuccess,
             onSignUp = onSignUp,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 
@@ -57,6 +59,7 @@ fun NavGraphBuilder.loginNavGraph(
         SignUpScreen(
             onSignUpSuccess = onSignUpSuccess,
             onNavigationButtonClick = onNavigationButtonClick,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/LoginScreen.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/LoginScreen.kt
@@ -13,10 +13,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,6 +50,7 @@ import java.util.UUID
 internal fun LoginScreen(
     onLoginSuccess: () -> Unit,
     onSignUp: (UserUiModel) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     loginViewModel: LoginViewModel = hiltViewModel(),
 ) {
@@ -71,6 +75,7 @@ internal fun LoginScreen(
     LoginScreen(
         loginViewModel::loginForExperience,
         handleSignIn = loginViewModel::handleSignIn,
+        snackbarHostState = snackbarHostState,
         setNewSnackBarMessage = loginViewModel::setNewSnackBarMessage,
     )
 }
@@ -79,9 +84,12 @@ internal fun LoginScreen(
 private fun LoginScreen(
     onLoginSuccess: () -> Unit,
     handleSignIn: (GetCredentialResponse, Int) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     setNewSnackBarMessage: (Int?) -> Unit,
 ) {
-    Scaffold { innerPadding ->
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/LoginScreen.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/LoginScreen.kt
@@ -13,13 +13,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,10 +47,10 @@ import java.util.UUID
 internal fun LoginScreen(
     onLoginSuccess: () -> Unit,
     onSignUp: (UserUiModel) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     loginViewModel: LoginViewModel = hiltViewModel(),
 ) {
     val loginUiState by loginViewModel.loginUiState.collectAsStateWithLifecycle()
-    val snackBarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
     LaunchedEffect(loginUiState) {
@@ -61,7 +58,7 @@ internal fun LoginScreen(
             onLoginSuccess()
         }
         loginUiState.snackBarMessage?.let { messageId ->
-            snackBarHostState.showSnackbar(context.getString(messageId))
+            onShowErrorSnackbar(Exception(context.getString(messageId)))
             loginViewModel.setNewSnackBarMessage(null)
         }
         if (loginUiState.isNewUser) {
@@ -72,7 +69,6 @@ internal fun LoginScreen(
     }
 
     LoginScreen(
-        snackBarHostState,
         loginViewModel::loginForExperience,
         handleSignIn = loginViewModel::handleSignIn,
         setNewSnackBarMessage = loginViewModel::setNewSnackBarMessage,
@@ -81,14 +77,11 @@ internal fun LoginScreen(
 
 @Composable
 private fun LoginScreen(
-    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onLoginSuccess: () -> Unit,
     handleSignIn: (GetCredentialResponse, Int) -> Unit,
     setNewSnackBarMessage: (Int?) -> Unit,
 ) {
-    Scaffold(
-        snackbarHost = { SnackbarHost(snackBarHostState) },
-    ) { innerPadding ->
+    Scaffold { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
@@ -15,11 +15,14 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -40,6 +43,7 @@ import kr.boostcamp_2024.course.login.viewmodel.SignUpViewModel
 internal fun SignUpScreen(
     onSignUpSuccess: () -> Unit,
     onNavigationButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: SignUpViewModel = hiltViewModel(),
 ) {
@@ -67,6 +71,7 @@ internal fun SignUpScreen(
         onSignUpButtonClick = viewModel::signUp,
         onEditButtonClick = viewModel::updateUser,
         onProfileByteArrayChanged = viewModel::onProfileByteArrayChanged,
+        snackbarHostState = snackbarHostState,
     )
 
     LaunchedEffect(uiState.isSubmitSuccess) {
@@ -89,6 +94,7 @@ private fun SignUpScreen(
     onNavigationButtonClick: () -> Unit,
     onSignUpButtonClick: () -> Unit,
     onEditButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         topBar = {
@@ -113,6 +119,7 @@ private fun SignUpScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.padding(

--- a/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
+++ b/feature/login/src/main/java/kr/boostcamp_2024/course/login/presentation/SignUpScreen.kt
@@ -15,14 +15,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -43,15 +40,15 @@ import kr.boostcamp_2024.course.login.viewmodel.SignUpViewModel
 internal fun SignUpScreen(
     onSignUpSuccess: () -> Unit,
     onNavigationButtonClick: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: SignUpViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.signUpUiState.collectAsStateWithLifecycle()
-    val snackBarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
     LaunchedEffect(uiState) {
         uiState.snackBarMessage?.let {
-            snackBarHostState.showSnackbar(context.getString(it))
+            onShowErrorSnackbar(Exception(context.getString(it)))
             viewModel.setNewSnackBarMessage(null)
         }
         if (uiState.isSignUpSuccess) {
@@ -65,7 +62,6 @@ internal fun SignUpScreen(
         isSignUpButtonEnabled = uiState.isSignUpButtonEnabled,
         isEditMode = uiState.isEditMode,
         profileImageByteArray = uiState.profileImageByteArray,
-        snackBarHostState = snackBarHostState,
         onNameChanged = viewModel::onNameChanged,
         onNavigationButtonClick = onNavigationButtonClick,
         onSignUpButtonClick = viewModel::signUp,
@@ -88,7 +84,6 @@ private fun SignUpScreen(
     isSignUpButtonEnabled: Boolean,
     isEditMode: Boolean,
     profileImageByteArray: ByteArray?,
-    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNameChanged: (String) -> Unit,
     onProfileByteArrayChanged: (ByteArray) -> Unit,
     onNavigationButtonClick: () -> Unit,
@@ -118,7 +113,6 @@ private fun SignUpScreen(
                 },
             )
         },
-        snackbarHost = { SnackbarHost(snackBarHostState) },
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.padding(

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/navigation/MainNavigation.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/navigation/MainNavigation.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.main.navigation
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -29,6 +30,7 @@ fun NavGraphBuilder.mainNavGraph(
     onStudyGroupClick: (String) -> Unit,
     onEditUserClick: (String?) -> Unit,
     onLoginOutClick: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<MainRoute> {
@@ -39,12 +41,14 @@ fun NavGraphBuilder.mainNavGraph(
             onEditStudyButtonClick = onEditStudyButtonClick,
             onEditUserClick = onEditUserClick,
             onLogOutClick = onLoginOutClick,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<NotificationRoute> {
         NotificationScreen(
             onNavigationButtonClick = onNavigationButtonClick,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/navigation/MainNavigation.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/navigation/MainNavigation.kt
@@ -29,6 +29,7 @@ fun NavGraphBuilder.mainNavGraph(
     onStudyGroupClick: (String) -> Unit,
     onEditUserClick: (String?) -> Unit,
     onLoginOutClick: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<MainRoute> {
         MainScreen(
@@ -38,11 +39,13 @@ fun NavGraphBuilder.mainNavGraph(
             onEditStudyButtonClick = onEditStudyButtonClick,
             onEditUserClick = onEditUserClick,
             onLogOutClick = onLoginOutClick,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<NotificationRoute> {
         NotificationScreen(
             onNavigationButtonClick = onNavigationButtonClick,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -67,6 +69,7 @@ internal fun MainScreen(
     onEditStudyButtonClick: (String) -> Unit,
     onEditUserClick: (String?) -> Unit,
     onLogOutClick: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: MainViewModel = hiltViewModel(),
 ) {
@@ -84,6 +87,7 @@ internal fun MainScreen(
         onStudyGroupClick = onStudyGroupClick,
         onEditUserClick = onEditUserClick,
         onLogOutClick = viewModel::logout,
+        snackbarHostState = snackbarHostState,
     )
 
     if (!uiState.isGuideShown) {
@@ -124,6 +128,7 @@ private fun MainScreen(
     onStudyGroupClick: (String) -> Unit,
     onEditUserClick: (String?) -> Unit,
     onLogOutClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
     var userMenuIsExpanded by remember { mutableStateOf(false) }
@@ -217,6 +222,7 @@ private fun MainScreen(
                 )
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
 
         Column(

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/MainScreen.kt
@@ -23,8 +23,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -69,8 +67,8 @@ internal fun MainScreen(
     onEditStudyButtonClick: (String) -> Unit,
     onEditUserClick: (String?) -> Unit,
     onLogOutClick: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: MainViewModel = hiltViewModel(),
-    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -78,7 +76,6 @@ internal fun MainScreen(
         currentUser = uiState.currentUser,
         studyGroups = uiState.studyGroups,
         notifications = uiState.notificationNumber,
-        snackBarHostState = snackBarHostState,
         onNotificationButtonClick = onNotificationButtonClick,
         onCreateStudyButtonClick = onCreateStudyButtonClick,
         onEditStudyGroupClick = onEditStudyButtonClick,
@@ -103,7 +100,7 @@ internal fun MainScreen(
 
     uiState.errorMessage?.let { errorMessage ->
         LaunchedEffect(errorMessage) {
-            snackBarHostState.showSnackbar(errorMessage)
+            onShowErrorSnackbar(Exception(errorMessage))
             viewModel.shownErrorMessage()
         }
     }
@@ -119,7 +116,6 @@ private fun MainScreen(
     currentUser: User?,
     studyGroups: List<StudyGroup>,
     notifications: Int,
-    snackBarHostState: SnackbarHostState,
     onNotificationButtonClick: () -> Unit,
     onCreateStudyButtonClick: () -> Unit,
     onEditStudyGroupClick: (String) -> Unit,
@@ -220,9 +216,6 @@ private fun MainScreen(
                     contentDescription = stringResource(R.string.des_fab_create_study),
                 )
             }
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = snackBarHostState)
         },
     ) { innerPadding ->
 
@@ -333,7 +326,6 @@ private fun MainScreenPreview() {
                     categories = emptyList(),
                 ),
             ),
-            snackBarHostState = SnackbarHostState(),
             onEditStudyGroupClick = {},
             onLeaveStudyGroupClick = {},
             onNotificationButtonClick = {},

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
@@ -7,13 +7,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -32,13 +29,13 @@ import kr.boostcamp_2024.course.main.viewmodel.NotificationViewModel
 internal fun NotificationScreen(
     viewModel: NotificationViewModel = hiltViewModel<NotificationViewModel>(),
     onNavigationButtonClick: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val notificationInfos = uiState.notificationWithGroupInfoList
-    val snackBarHostState = remember { SnackbarHostState() }
     LaunchedEffect(uiState) {
         uiState.snackBarMessage?.let { message ->
-            snackBarHostState.showSnackbar(message)
+            onShowErrorSnackbar(Exception(message))
             viewModel.onSnackBarShown()
         }
     }
@@ -48,7 +45,6 @@ internal fun NotificationScreen(
         onRejectClick = viewModel::deleteInvitation,
         onAcceptClick = viewModel::acceptInvitation,
         onNavigationButtonClick = onNavigationButtonClick,
-        snackBarHostState = snackBarHostState,
     )
 }
 
@@ -59,10 +55,8 @@ private fun NotificationScreen(
     onRejectClick: (String) -> Unit,
     onAcceptClick: (Notification) -> Unit,
     onNavigationButtonClick: () -> Unit,
-    snackBarHostState: SnackbarHostState,
 ) {
     Scaffold(
-        snackbarHost = { SnackbarHost(snackBarHostState) },
         topBar = {
             NotificationTopAppBar(onNavigationButtonClick = onNavigationButtonClick)
         },
@@ -117,7 +111,6 @@ private fun NotificationScreenPreview() {
             onRejectClick = {},
             onAcceptClick = {},
             onNavigationButtonClick = {},
-            snackBarHostState = SnackbarHostState(),
         )
     }
 }

--- a/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
+++ b/feature/main/src/main/java/kr/boostcamp_2024/course/main/presentation/NotificationScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -29,6 +32,7 @@ import kr.boostcamp_2024.course.main.viewmodel.NotificationViewModel
 internal fun NotificationScreen(
     viewModel: NotificationViewModel = hiltViewModel<NotificationViewModel>(),
     onNavigationButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -45,6 +49,7 @@ internal fun NotificationScreen(
         onRejectClick = viewModel::deleteInvitation,
         onAcceptClick = viewModel::acceptInvitation,
         onNavigationButtonClick = onNavigationButtonClick,
+        snackbarHostState = snackbarHostState,
     )
 }
 
@@ -55,11 +60,13 @@ private fun NotificationScreen(
     onRejectClick: (String) -> Unit,
     onAcceptClick: (Notification) -> Unit,
     onNavigationButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         topBar = {
             NotificationTopAppBar(onNavigationButtonClick = onNavigationButtonClick)
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         if (notificationInfos.isEmpty()) {
             Box(

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/navigation/QuizNavigation.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/navigation/QuizNavigation.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.quiz.navigation
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -80,18 +81,21 @@ fun NavGraphBuilder.quizNavGraph(
     onSettingMenuClick: (String, String) -> Unit,
     onEditQuizSuccess: () -> Unit,
     onQuizDeleteSuccess: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<CreateQuestionRoute> {
         CreateQuestionScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateQuestionSuccess = onCreateQuestionSuccess,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<QuestionDetailRoute> {
         QuestionDetailScreen(
             onNavigationButtonClick = onNavigationButtonClick,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
@@ -99,6 +103,7 @@ fun NavGraphBuilder.quizNavGraph(
         QuestionScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onQuizFinished = onQuizFinished,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
@@ -109,6 +114,7 @@ fun NavGraphBuilder.quizNavGraph(
             onStartQuizButtonClick = onStartQuizButtonClick,
             onSettingMenuClick = onSettingMenuClick,
             onQuizDeleteSuccess = onQuizDeleteSuccess,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
@@ -116,6 +122,7 @@ fun NavGraphBuilder.quizNavGraph(
         QuizResultScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onQuestionClick = onQuestionClick,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
@@ -124,6 +131,7 @@ fun NavGraphBuilder.quizNavGraph(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateQuizSuccess = onCreateQuizSuccess,
             onEditQuizSuccess = onEditQuizSuccess,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/navigation/QuizNavigation.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/navigation/QuizNavigation.kt
@@ -80,22 +80,26 @@ fun NavGraphBuilder.quizNavGraph(
     onSettingMenuClick: (String, String) -> Unit,
     onEditQuizSuccess: () -> Unit,
     onQuizDeleteSuccess: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<CreateQuestionRoute> {
         CreateQuestionScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateQuestionSuccess = onCreateQuestionSuccess,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<QuestionDetailRoute> {
         QuestionDetailScreen(
             onNavigationButtonClick = onNavigationButtonClick,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<QuestionRoute> {
         QuestionScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onQuizFinished = onQuizFinished,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<QuizRoute> {
@@ -105,12 +109,14 @@ fun NavGraphBuilder.quizNavGraph(
             onStartQuizButtonClick = onStartQuizButtonClick,
             onSettingMenuClick = onSettingMenuClick,
             onQuizDeleteSuccess = onQuizDeleteSuccess,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<QuizResultRoute> {
         QuizResultScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onQuestionClick = onQuestionClick,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
     composable<CreateQuizRoute> {
@@ -118,6 +124,7 @@ fun NavGraphBuilder.quizNavGraph(
             onNavigationButtonClick = onNavigationButtonClick,
             onCreateQuizSuccess = onCreateQuizSuccess,
             onEditQuizSuccess = onEditQuizSuccess,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
@@ -26,8 +26,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -61,10 +59,10 @@ import kr.boostcamp_2024.course.quiz.viewmodel.CreateQuestionViewModel
 internal fun CreateQuestionScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateQuestionSuccess: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: CreateQuestionViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.createQuestionUiState.collectAsStateWithLifecycle()
-    val snackBarHostState = remember { SnackbarHostState() }
     val focusRequester = remember { FocusRequester() }
     val options = listOf(
         stringResource(R.string.txt_create_general_question),
@@ -75,7 +73,7 @@ internal fun CreateQuestionScreen(
             onCreateQuestionSuccess()
         }
         uiState.snackBarMessage?.let { message ->
-            snackBarHostState.showSnackbar(message)
+            onShowErrorSnackbar(Exception(message))
             viewModel.setNewSnackBarMessage(null)
         }
     }
@@ -91,7 +89,6 @@ internal fun CreateQuestionScreen(
 
     CreateQuestionScreen(
         uiState = uiState,
-        snackBarHostState = snackBarHostState,
         focusRequester = focusRequester,
         onTitleChanged = viewModel::onTitleChanged,
         onDescriptionChanged = viewModel::onDescriptionChanged,
@@ -121,7 +118,6 @@ internal fun CreateQuestionScreen(
 private fun CreateQuestionScreen(
     uiState: CreateQuestionUiState,
     focusRequester: FocusRequester,
-    snackBarHostState: SnackbarHostState,
     onTitleChanged: (String) -> Unit,
     onDescriptionChanged: (String) -> Unit,
     onSolutionChanged: (String) -> Unit,
@@ -146,7 +142,6 @@ private fun CreateQuestionScreen(
     val focusManager = LocalFocusManager.current
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackBarHostState) },
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
@@ -326,7 +321,6 @@ private fun CreateQuestionScreenPreview() {
         CreateQuestionScreen(
             uiState = previewCreateQuestionUiState,
             focusRequester = remember { FocusRequester() },
-            snackBarHostState = remember { SnackbarHostState() },
             onTitleChanged = {},
             onDescriptionChanged = {},
             onSolutionChanged = {},

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/CreateQuestionScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -59,6 +61,7 @@ import kr.boostcamp_2024.course.quiz.viewmodel.CreateQuestionViewModel
 internal fun CreateQuestionScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateQuestionSuccess: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: CreateQuestionViewModel = hiltViewModel(),
 ) {
@@ -110,6 +113,7 @@ internal fun CreateQuestionScreen(
         isCreateBlankButtonValid = uiState.isCreateBlankButtonValid,
         isCreateTextButtonValid = uiState.isCreateTextButtonValid,
         onShowDialog = viewModel::showDialog,
+        snackbarHostState = snackbarHostState,
     )
 }
 
@@ -138,6 +142,7 @@ private fun CreateQuestionScreen(
     isCreateBlankButtonValid: Boolean,
     isCreateTextButtonValid: Boolean,
     onShowDialog: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val focusManager = LocalFocusManager.current
 
@@ -161,6 +166,7 @@ private fun CreateQuestionScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         val imeInsets = WindowInsets.ime
         val density = LocalDensity.current

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -54,7 +52,6 @@ internal fun GeneralQuestionScreen(
     questions: List<Question>,
     countDownTime: Int,
     selectedIndexList: List<Any>,
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNavigationButtonClick: () -> Unit,
     onOptionSelected: (Int, Int) -> Unit,
     onBlanksSelected: (Int, Map<String, String?>) -> Unit,
@@ -85,9 +82,6 @@ internal fun GeneralQuestionScreen(
                     onShowDialog = { showDialog = true },
                 )
             }
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState)
         },
     ) { innerPadding ->
         LinearProgressIndicator(
@@ -272,7 +266,6 @@ private fun GeneralQuestionScreenPreview() {
             questions = emptyList(),
             countDownTime = 0,
             selectedIndexList = emptyList(),
-            snackbarHostState = SnackbarHostState(),
             onNavigationButtonClick = {},
             onOptionSelected = { _, _ -> },
             onNextButtonClick = {},

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/GeneralQuestionScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -65,6 +67,7 @@ internal fun GeneralQuestionScreen(
     addBlankContent: (Int) -> Unit,
     getBlankQuestionAnswer: () -> Map<String, String?>,
     isLoading: Boolean,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
     var buttonsHeight by remember { mutableStateOf(IntSize.Zero) }
@@ -83,6 +86,7 @@ internal fun GeneralQuestionScreen(
                 )
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         LinearProgressIndicator(
             progress = { (currentPage + 1) / questions.size.toFloat() },

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -52,6 +54,7 @@ internal fun OwnerQuestionScreen(
     quiz: RealTimeQuiz?,
     currentUserId: String?,
     onQuizFinished: (String?, String?) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     questionViewModel: OwnerQuestionViewModel = hiltViewModel(),
 ) {
@@ -76,6 +79,7 @@ internal fun OwnerQuestionScreen(
         removeBlankWord = questionViewModel.blankQuestionManager::removeBlankContent,
         addBlankWord = questionViewModel.blankQuestionManager::addBlankContent,
         getBlankQuestionAnswer = questionViewModel.blankQuestionManager::getAnswer,
+        snackbarHostState = snackbarHostState,
     )
 
     if (uiState.isQuizFinished) {
@@ -107,6 +111,7 @@ private fun OwnerQuestionScreen(
     removeBlankWord: (Int) -> Unit,
     addBlankWord: (Int) -> Unit,
     getBlankQuestionAnswer: () -> Map<String, String?>,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     var showQuitQuizDialog by rememberSaveable { mutableStateOf(false) }
     var showFinishQuizDialog by rememberSaveable { mutableStateOf(false) }
@@ -127,6 +132,7 @@ private fun OwnerQuestionScreen(
                 )
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Box(
             modifier = Modifier

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/OwnerQuestionScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -54,8 +52,8 @@ internal fun OwnerQuestionScreen(
     quiz: RealTimeQuiz?,
     currentUserId: String?,
     onQuizFinished: (String?, String?) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     questionViewModel: OwnerQuestionViewModel = hiltViewModel(),
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val uiState by questionViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -69,7 +67,6 @@ internal fun OwnerQuestionScreen(
         currentPage = uiState.currentPage,
         choiceQuestions = uiState.questions,
         ownerName = uiState.ownerName ?: "",
-        snackbarHostState = snackbarHostState,
         onNextButtonClick = questionViewModel::nextPage,
         onPreviousButtonClick = questionViewModel::previousPage,
         onQuizFinishButtonClick = questionViewModel::setQuizFinished,
@@ -88,7 +85,7 @@ internal fun OwnerQuestionScreen(
     uiState.errorMessageId?.let { errorMessageId ->
         val errorMessage = stringResource(errorMessageId)
         LaunchedEffect(errorMessageId) {
-            snackbarHostState.showSnackbar(errorMessage)
+            onShowErrorSnackbar(Exception(errorMessage))
             questionViewModel.shownErrorMessage()
         }
     }
@@ -101,7 +98,6 @@ private fun OwnerQuestionScreen(
     currentPage: Int,
     choiceQuestions: List<Question?>,
     ownerName: String,
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNextButtonClick: () -> Unit,
     onPreviousButtonClick: () -> Unit,
     onQuizFinishButtonClick: () -> Unit,
@@ -130,9 +126,6 @@ private fun OwnerQuestionScreen(
                     onShowDialog = { showQuitQuizDialog = true },
                 )
             }
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState)
         },
     ) { innerPadding ->
         Box(

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionDetailScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionDetailScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -44,6 +46,7 @@ import kr.boostcamp_2024.course.quiz.viewmodel.QuestionDetailViewModel
 @Composable
 internal fun QuestionDetailScreen(
     onNavigationButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: QuestionDetailViewModel = hiltViewModel<QuestionDetailViewModel>(),
 ) {
@@ -53,6 +56,7 @@ internal fun QuestionDetailScreen(
         question = uiState.question,
         userAnswer = uiState.userAnswer,
         onNavigationButtonClick = onNavigationButtonClick,
+        snackbarHostState = snackbarHostState,
     )
 
     uiState.errorMessage?.let { message ->
@@ -69,6 +73,7 @@ private fun QuestionDetailScreen(
     question: Question?,
     userAnswer: List<Int>,
     onNavigationButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val scrollState = rememberScrollState()
     var showDialog by remember { mutableStateOf(false) }
@@ -98,6 +103,7 @@ private fun QuestionDetailScreen(
                 )
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         Column(
             modifier = Modifier

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionDetailScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionDetailScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -45,36 +43,38 @@ import kr.boostcamp_2024.course.quiz.viewmodel.QuestionDetailViewModel
 
 @Composable
 internal fun QuestionDetailScreen(
-    viewModel: QuestionDetailViewModel = hiltViewModel<QuestionDetailViewModel>(),
     onNavigationButtonClick: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
+    viewModel: QuestionDetailViewModel = hiltViewModel<QuestionDetailViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     QuestionDetailScreen(
         question = uiState.question,
-        errorMessage = uiState.errorMessage,
-        onNavigationButtonClick = onNavigationButtonClick,
-        onErrorMessageShown = viewModel::shownErrorMessage,
         userAnswer = uiState.userAnswer,
+        onNavigationButtonClick = onNavigationButtonClick,
     )
+
+    uiState.errorMessage?.let { message ->
+        LaunchedEffect(message) {
+            onShowErrorSnackbar(Exception(message))
+            viewModel.shownErrorMessage()
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun QuestionDetailScreen(
     question: Question?,
-    errorMessage: String?,
-    onNavigationButtonClick: () -> Unit,
-    onErrorMessageShown: () -> Unit = {},
     userAnswer: List<Int>,
+    onNavigationButtonClick: () -> Unit,
 ) {
-    val snackBarHostState = remember { SnackbarHostState() }
     val scrollState = rememberScrollState()
     var showDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = { QuestionDetailTopAppBar(onNavigationButtonClick = onNavigationButtonClick) },
-        snackbarHost = { SnackbarHost(hostState = snackBarHostState) },
         floatingActionButton = {
             if (question is ChoiceQuestion) {
                 ExtendedFloatingActionButton(
@@ -129,12 +129,6 @@ private fun QuestionDetailScreen(
                 )
             }
         }
-        if (errorMessage != null) {
-            LaunchedEffect(errorMessage) {
-                snackBarHostState.showSnackbar(errorMessage)
-                onErrorMessageShown()
-            }
-        }
     }
 }
 
@@ -147,7 +141,6 @@ private fun QuestionDetailScreenPreview(
         QuestionDetailScreen(
             onNavigationButtonClick = {},
             question = question,
-            errorMessage = null,
             userAnswer = listOf(0, 0, 0, 0),
         )
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.quiz.presentation.question
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -14,6 +15,7 @@ import kr.boostcamp_2024.course.quiz.viewmodel.QuestionViewModel
 internal fun QuestionScreen(
     onNavigationButtonClick: () -> Unit,
     onQuizFinished: (String?, String?) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     questionViewModel: QuestionViewModel = hiltViewModel(),
 ) {
@@ -27,6 +29,7 @@ internal fun QuestionScreen(
                 quiz = quiz,
                 currentUserId = uiState.currentUserId,
                 onQuizFinished = { _, quizId -> onQuizFinished(null, quizId) },
+                snackbarHostState = snackbarHostState,
                 onShowErrorSnackbar = onShowErrorSnackbar,
             )
         } else {
@@ -35,6 +38,7 @@ internal fun QuestionScreen(
                 onQuizFinished = { userOmrId, _ ->
                     onQuizFinished(userOmrId, null)
                 },
+                snackbarHostState = snackbarHostState,
                 onShowErrorSnackbar = onShowErrorSnackbar,
             )
         }
@@ -59,6 +63,7 @@ internal fun QuestionScreen(
                 addBlankContent = questionViewModel.blankQuestionManager::addBlankContent,
                 getBlankQuestionAnswer = questionViewModel.blankQuestionManager::getAnswer,
                 isLoading = uiState.isLoading,
+                snackbarHostState = snackbarHostState,
             )
         }
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/QuestionScreen.kt
@@ -1,10 +1,8 @@
 package kr.boostcamp_2024.course.quiz.presentation.question
 
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -16,10 +14,10 @@ import kr.boostcamp_2024.course.quiz.viewmodel.QuestionViewModel
 internal fun QuestionScreen(
     onNavigationButtonClick: () -> Unit,
     onQuizFinished: (String?, String?) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     questionViewModel: QuestionViewModel = hiltViewModel(),
 ) {
     val uiState by questionViewModel.uiState.collectAsStateWithLifecycle()
-    val snackbarHostState = remember { SnackbarHostState() }
 
     if (uiState.quiz is RealTimeQuiz) {
         val quiz = uiState.quiz as RealTimeQuiz
@@ -29,6 +27,7 @@ internal fun QuestionScreen(
                 quiz = quiz,
                 currentUserId = uiState.currentUserId,
                 onQuizFinished = { _, quizId -> onQuizFinished(null, quizId) },
+                onShowErrorSnackbar = onShowErrorSnackbar,
             )
         } else {
             UserQuestionScreen(
@@ -36,6 +35,7 @@ internal fun QuestionScreen(
                 onQuizFinished = { userOmrId, _ ->
                     onQuizFinished(userOmrId, null)
                 },
+                onShowErrorSnackbar = onShowErrorSnackbar,
             )
         }
     } else if (uiState.quiz is Quiz) {
@@ -46,7 +46,6 @@ internal fun QuestionScreen(
                 questions = uiState.questions,
                 countDownTime = currentCountDownTime,
                 selectedIndexList = uiState.selectedIndexList,
-                snackbarHostState = snackbarHostState,
                 onOptionSelected = questionViewModel::selectOption,
                 onNextButtonClick = questionViewModel::nextPage,
                 onPreviousButtonClick = questionViewModel::previousPage,
@@ -67,7 +66,7 @@ internal fun QuestionScreen(
     uiState.errorMessageId?.let { errorMessageId ->
         val errorMessage = stringResource(errorMessageId)
         LaunchedEffect(errorMessageId) {
-            snackbarHostState.showSnackbar(errorMessage)
+            onShowErrorSnackbar(Exception(errorMessage))
             questionViewModel.shownErrorMessage()
         }
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -42,6 +45,7 @@ import kr.boostcamp_2024.course.quiz.viewmodel.UserQuestionViewModel
 internal fun UserQuestionScreen(
     onNavigationButtonClick: () -> Unit,
     onQuizFinished: (String?, String?) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     userQuestionViewModel: UserQuestionViewModel = hiltViewModel(),
 ) {
@@ -67,6 +71,7 @@ internal fun UserQuestionScreen(
         addBlankContent = userQuestionViewModel.blankQuestionManager::addBlankContent,
         getBlankQuestionAnswer = userQuestionViewModel.blankQuestionManager::getAnswer,
         onExitButtonClick = userQuestionViewModel::exitRealTimeQuiz,
+        snackbarHostState = snackbarHostState,
     )
 
     uiState.errorMessageId?.let { errorMessageId ->
@@ -114,6 +119,7 @@ private fun UserQuestionScreen(
     addBlankContent: (Int) -> Unit,
     getBlankQuestionAnswer: () -> Map<String, String?>,
     onExitButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     var showExitDialog by rememberSaveable { mutableStateOf(false) }
     val currentQuestion = choiceQuestions.getOrNull(currentPage)
@@ -132,6 +138,7 @@ private fun UserQuestionScreen(
                 )
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Box(
             modifier = Modifier

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/question/UserQuestionScreen.kt
@@ -10,14 +10,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -45,11 +42,11 @@ import kr.boostcamp_2024.course.quiz.viewmodel.UserQuestionViewModel
 internal fun UserQuestionScreen(
     onNavigationButtonClick: () -> Unit,
     onQuizFinished: (String?, String?) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     userQuestionViewModel: UserQuestionViewModel = hiltViewModel(),
 ) {
     val uiState by userQuestionViewModel.uiState.collectAsStateWithLifecycle()
     var quizFinishDialog by rememberSaveable { mutableStateOf(false) }
-    val snackbarHostState = remember { SnackbarHostState() }
 
     UserQuestionScreen(
         quiz = uiState.quiz,
@@ -59,7 +56,6 @@ internal fun UserQuestionScreen(
         quizFinishDialog = quizFinishDialog,
         onQuizFinishDialogDismissButtonClick = { quizFinishDialog = false },
         selectedIndexList = uiState.selectedIndexList,
-        snackbarHostState = snackbarHostState,
         onOptionSelected = userQuestionViewModel::selectOption,
         onBlanksSelected = userQuestionViewModel::selectBlanks,
         onSubmitButtonClick = userQuestionViewModel::submitQuestion,
@@ -76,7 +72,7 @@ internal fun UserQuestionScreen(
     uiState.errorMessageId?.let { errorMessageId ->
         val errorMessage = stringResource(errorMessageId)
         LaunchedEffect(errorMessageId) {
-            snackbarHostState.showSnackbar(errorMessage)
+            onShowErrorSnackbar(Exception(errorMessage))
             userQuestionViewModel.shownErrorMessage()
         }
     }
@@ -107,7 +103,6 @@ private fun UserQuestionScreen(
     quizFinishDialog: Boolean,
     onQuizFinishDialogDismissButtonClick: () -> Unit,
     selectedIndexList: List<Any?>,
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onOptionSelected: (Int, Int) -> Unit,
     onBlanksSelected: (Int, Map<String, String?>) -> Unit,
     onSubmitButtonClick: (String) -> Unit,
@@ -136,9 +131,6 @@ private fun UserQuestionScreen(
                     onShowDialog = { showExitDialog = true },
                 )
             }
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState)
         },
     ) { innerPadding ->
         Box(

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/CreateQuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/CreateQuizScreen.kt
@@ -20,12 +20,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -47,8 +44,8 @@ internal fun CreateQuizScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateQuizSuccess: () -> Unit,
     onEditQuizSuccess: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: CreateQuizViewModel = hiltViewModel(),
-    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -60,7 +57,6 @@ internal fun CreateQuizScreen(
         createQuizButtonEnabled = uiState.value.isCreateQuizButtonEnabled && !uiState.value.isLoading,
         isEditing = uiState.value.isEditing,
         selectedQuizTypeIndex = uiState.value.selectedQuizTypeIndex,
-        snackBarHostState = snackBarHostState,
         defaultImageUrl = uiState.value.defaultImageUrl,
         onQuizTitleChange = viewModel::setQuizTitle,
         onQuizDescriptionChange = viewModel::setQuizDescription,
@@ -93,7 +89,7 @@ internal fun CreateQuizScreen(
 
     LaunchedEffect(uiState.value.snackBarMessage) {
         uiState.value.snackBarMessage?.let { snackBarMessage ->
-            snackBarHostState.showSnackbar(snackBarMessage)
+            onShowErrorSnackbar(Exception(snackBarMessage))
             viewModel.shownErrorMessage()
         }
     }
@@ -111,7 +107,6 @@ private fun CreateQuizScreen(
     selectedQuizTypeIndex: Int,
     isRealtimeQuiz: Boolean,
     currentImage: ByteArray?,
-    snackBarHostState: SnackbarHostState,
     defaultImageUrl: String?,
     onQuizTitleChange: (String) -> Unit,
     onQuizDescriptionChange: (String) -> Unit,
@@ -144,9 +139,6 @@ private fun CreateQuizScreen(
                     }
                 },
             )
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = snackBarHostState)
         },
     ) { innerPadding ->
         Column(
@@ -261,7 +253,6 @@ private fun CreateQuizScreenPreview() {
             isEditing = false,
             isRealtimeQuiz = false,
             currentImage = null,
-            snackBarHostState = remember { SnackbarHostState() },
             defaultImageUrl = null,
             onQuizTitleChange = {},
             onQuizDescriptionChange = {},

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/CreateQuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/CreateQuizScreen.kt
@@ -20,9 +20,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -44,6 +47,7 @@ internal fun CreateQuizScreen(
     onNavigationButtonClick: () -> Unit,
     onCreateQuizSuccess: () -> Unit,
     onEditQuizSuccess: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: CreateQuizViewModel = hiltViewModel(),
 ) {
@@ -69,6 +73,7 @@ internal fun CreateQuizScreen(
         onCurrentStudyImageChanged = viewModel::changeCurrentStudyImage,
         isRealtimeQuiz = uiState.value.isRealtimeQuiz,
         onQuizTypeIndexChange = viewModel::setSelectedQuizTypeIndex,
+        snackbarHostState = snackbarHostState,
     )
 
     if (uiState.value.isCreateQuizSuccess) {
@@ -117,6 +122,7 @@ private fun CreateQuizScreen(
     onEditButtonClick: () -> Unit,
     onCurrentStudyImageChanged: (ByteArray) -> Unit,
     onQuizTypeIndexChange: (Int) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val options = listOf(stringResource(R.string.txt_create_quiz_general), stringResource(R.string.txt_create_quiz_realtime))
 
@@ -140,6 +146,7 @@ private fun CreateQuizScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/GeneralQuizResultScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/GeneralQuizResultScreen.kt
@@ -23,9 +23,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,6 +52,7 @@ internal fun GeneralQuizResultScreen(
     quizResult: QuizResult?,
     onNavigationButtonClick: () -> Unit,
     onQuestionClick: (String) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -71,6 +75,7 @@ internal fun GeneralQuizResultScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
 
         quizResult?.let { quizResult ->

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/GeneralQuizResultScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/GeneralQuizResultScreen.kt
@@ -23,12 +23,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,7 +49,6 @@ internal fun GeneralQuizResultScreen(
     quizResult: QuizResult?,
     onNavigationButtonClick: () -> Unit,
     onQuestionClick: (String) -> Unit,
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -75,7 +71,6 @@ internal fun GeneralQuizResultScreen(
                 },
             )
         },
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { innerPadding ->
 
         quizResult?.let { quizResult ->
@@ -221,7 +216,6 @@ private fun GeneralQuizResultScreenPreview() {
             ),
             onNavigationButtonClick = {},
             onQuestionClick = { _ -> },
-            snackbarHostState = remember { SnackbarHostState() },
         )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/OwnerQuizResultScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/OwnerQuizResultScreen.kt
@@ -23,8 +23,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,6 +50,7 @@ internal fun OwnerQuizResultScreen(
     quizTitle: String?,
     onQuestionClick: (String) -> Unit,
     onNavigationButtonClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -69,6 +73,7 @@ internal fun OwnerQuizResultScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
 
         Column(

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/OwnerQuizResultScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/OwnerQuizResultScreen.kt
@@ -23,11 +23,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -50,7 +47,6 @@ internal fun OwnerQuizResultScreen(
     quizTitle: String?,
     onQuestionClick: (String) -> Unit,
     onNavigationButtonClick: () -> Unit,
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -73,7 +69,6 @@ internal fun OwnerQuizResultScreen(
                 },
             )
         },
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { innerPadding ->
 
         Column(
@@ -194,7 +189,6 @@ private fun OwnerQuizResultScreenPreview() {
             onQuestionClick = {},
             questions = quizResultPreviewQuestions,
             quizTitle = "퀴즈 결과 프리뷰",
-            snackbarHostState = remember { SnackbarHostState() },
         )
     }
 }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizResultScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizResultScreen.kt
@@ -3,11 +3,9 @@ package kr.boostcamp_2024.course.quiz.presentation.quiz
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -21,8 +19,8 @@ import kr.boostcamp_2024.course.quiz.viewmodel.QuizResultViewModel
 internal fun QuizResultScreen(
     onNavigationButtonClick: () -> Unit,
     onQuestionClick: (String) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     quizResultViewModel: QuizResultViewModel = hiltViewModel(),
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val uiState by quizResultViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -30,7 +28,6 @@ internal fun QuizResultScreen(
         OwnerQuizResultScreen(
             questions = uiState.questions,
             quizTitle = uiState.quizTitle,
-            snackbarHostState = snackbarHostState,
             onNavigationButtonClick = onNavigationButtonClick,
             onQuestionClick = onQuestionClick,
         )
@@ -39,7 +36,6 @@ internal fun QuizResultScreen(
             quizTitle = uiState.quizTitle,
             quizResult = uiState.quizResult,
             onNavigationButtonClick = onNavigationButtonClick,
-            snackbarHostState = snackbarHostState,
             onQuestionClick = onQuestionClick,
         )
     }
@@ -56,7 +52,7 @@ internal fun QuizResultScreen(
 
     uiState.errorMessage?.let { errorMessage ->
         LaunchedEffect(errorMessage) {
-            snackbarHostState.showSnackbar(errorMessage)
+            onShowErrorSnackbar(Exception(errorMessage))
             quizResultViewModel.shownErrorMessage()
         }
     }

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizResultScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizResultScreen.kt
@@ -3,6 +3,7 @@ package kr.boostcamp_2024.course.quiz.presentation.quiz
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -19,6 +20,7 @@ import kr.boostcamp_2024.course.quiz.viewmodel.QuizResultViewModel
 internal fun QuizResultScreen(
     onNavigationButtonClick: () -> Unit,
     onQuestionClick: (String) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     quizResultViewModel: QuizResultViewModel = hiltViewModel(),
 ) {
@@ -30,6 +32,7 @@ internal fun QuizResultScreen(
             quizTitle = uiState.quizTitle,
             onNavigationButtonClick = onNavigationButtonClick,
             onQuestionClick = onQuestionClick,
+            snackbarHostState = snackbarHostState,
         )
     } else {
         GeneralQuizResultScreen(
@@ -37,6 +40,7 @@ internal fun QuizResultScreen(
             quizResult = uiState.quizResult,
             onNavigationButtonClick = onNavigationButtonClick,
             onQuestionClick = onQuestionClick,
+            snackbarHostState = snackbarHostState,
         )
     }
 

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -12,13 +12,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -49,7 +46,7 @@ internal fun QuizScreen(
     onStartQuizButtonClick: (String) -> Unit,
     onSettingMenuClick: (String, String) -> Unit,
     onQuizDeleteSuccess: () -> Unit,
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: QuizViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -64,7 +61,6 @@ internal fun QuizScreen(
         category = uiState.category,
         quiz = uiState.quiz,
         currentUserId = uiState.currentUserId,
-        snackbarHostState = snackbarHostState,
         onNavigationButtonClick = onNavigationButtonClick,
         onCreateQuestionButtonClick = onCreateQuestionButtonClick,
         onStartQuizButtonClick = onStartQuizButtonClick,
@@ -97,7 +93,7 @@ internal fun QuizScreen(
 
     uiState.errorMessage?.let { errorMessage ->
         LaunchedEffect(errorMessage) {
-            snackbarHostState.showSnackbar(errorMessage)
+            onShowErrorSnackbar(Exception(errorMessage))
             viewModel.shownErrorMessage()
         }
     }
@@ -108,7 +104,6 @@ private fun QuizScreen(
     category: Category?,
     quiz: BaseQuiz?,
     currentUserId: String?,
-    snackbarHostState: SnackbarHostState,
     onNavigationButtonClick: () -> Unit,
     onCreateQuestionButtonClick: (String) -> Unit,
     onStartQuizButtonClick: (String) -> Unit,
@@ -129,9 +124,6 @@ private fun QuizScreen(
                 onDeleteMenuClick = onDeleteMenuClick,
                 onWaitingRealTimeQuizButtonClick = onWaitingRealTimeQuizButtonClick,
             )
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState)
         },
     ) { innerPadding ->
         Box(
@@ -240,7 +232,6 @@ private fun QuizStartScreenPreview() {
                 userOmrs = emptyList(),
                 quizImageUrl = "quizImageUrl",
             ),
-            snackbarHostState = SnackbarHostState(),
             onNavigationButtonClick = {},
             onCreateQuestionButtonClick = {},
             onStartQuizButtonClick = {},

--- a/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
+++ b/feature/quiz/src/main/java/kr/boostcamp_2024/course/quiz/presentation/quiz/QuizScreen.kt
@@ -12,10 +12,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -46,6 +49,7 @@ internal fun QuizScreen(
     onStartQuizButtonClick: (String) -> Unit,
     onSettingMenuClick: (String, String) -> Unit,
     onQuizDeleteSuccess: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: QuizViewModel = hiltViewModel(),
 ) {
@@ -68,6 +72,7 @@ internal fun QuizScreen(
         onDeleteMenuClick = viewModel::deleteQuiz,
         onStartRealTimeQuizButtonClick = viewModel::startRealTimeQuiz,
         onWaitingRealTimeQuizButtonClick = viewModel::waitingRealTimeQuiz,
+        snackbarHostState = snackbarHostState,
     )
 
     if (uiState.isLoading) {
@@ -111,6 +116,7 @@ private fun QuizScreen(
     onDeleteMenuClick: (String, BaseQuiz) -> Unit,
     onStartRealTimeQuizButtonClick: () -> Unit,
     onWaitingRealTimeQuizButtonClick: (Boolean) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -125,6 +131,7 @@ private fun QuizScreen(
                 onWaitingRealTimeQuizButtonClick = onWaitingRealTimeQuizButtonClick,
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Box(
             modifier = Modifier

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
@@ -33,11 +33,13 @@ fun NavGraphBuilder.studyNavGraph(
     onEditStudyGroupButtonClick: (String) -> Unit,
     onCategoryClick: (String, String) -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<CreateStudyRoute> {
         CreateStudyScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onSubmitStudySuccess = onSubmitStudySuccess,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 
@@ -49,6 +51,7 @@ fun NavGraphBuilder.studyNavGraph(
             onCategoryClick = onCategoryClick,
             onDeleteStudyGroupSuccess = onDeleteStudyGroupSuccess,
             onLeaveStudyGroupSuccess = onLeaveStudyGroupSuccess,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/navigation/StudyNavigation.kt
@@ -1,5 +1,6 @@
 package kr.boostcamp_2024.course.study.navigation
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -33,12 +34,14 @@ fun NavGraphBuilder.studyNavGraph(
     onEditStudyGroupButtonClick: (String) -> Unit,
     onCategoryClick: (String, String) -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<CreateStudyRoute> {
         CreateStudyScreen(
             onNavigationButtonClick = onNavigationButtonClick,
             onSubmitStudySuccess = onSubmitStudySuccess,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
@@ -51,6 +54,7 @@ fun NavGraphBuilder.studyNavGraph(
             onCategoryClick = onCategoryClick,
             onDeleteStudyGroupSuccess = onDeleteStudyGroupSuccess,
             onLeaveStudyGroupSuccess = onLeaveStudyGroupSuccess,
+            snackbarHostState = snackbarHostState,
             onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -12,9 +12,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -36,6 +39,7 @@ import kr.boostcamp_2024.course.study.component.StudySubmitButton
 internal fun CreateStudyScreen(
     onNavigationButtonClick: () -> Unit,
     onSubmitStudySuccess: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewmodel: CreateStudyViewModel = hiltViewModel<CreateStudyViewModel>(),
 ) {
@@ -56,6 +60,7 @@ internal fun CreateStudyScreen(
         onStudyEditButtonClick = viewmodel::updateStudyGroup,
         onCreationButtonClick = viewmodel::createStudyGroupClick,
         onCurrentStudyImageChanged = viewmodel::onImageByteArrayChanged,
+        snackbarHostState = snackbarHostState,
     )
 
     if (uiState.isLoading) {
@@ -93,6 +98,7 @@ private fun CreateStudyScreen(
     onStudyEditButtonClick: () -> Unit,
     onCreationButtonClick: () -> Unit,
     onCurrentStudyImageChanged: (ByteArray) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val scrollState = rememberScrollState()
 
@@ -103,6 +109,7 @@ private fun CreateStudyScreen(
                 onNavigationButtonClick = onNavigationButtonClick,
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         Column(
             modifier = Modifier

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/CreateStudyScreen.kt
@@ -12,12 +12,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
@@ -37,10 +34,10 @@ import kr.boostcamp_2024.course.study.component.StudySubmitButton
 
 @Composable
 internal fun CreateStudyScreen(
-    viewmodel: CreateStudyViewModel = hiltViewModel<CreateStudyViewModel>(),
-    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNavigationButtonClick: () -> Unit,
     onSubmitStudySuccess: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
+    viewmodel: CreateStudyViewModel = hiltViewModel<CreateStudyViewModel>(),
 ) {
     val uiState by viewmodel.uiState.collectAsStateWithLifecycle()
 
@@ -52,7 +49,6 @@ internal fun CreateStudyScreen(
         descriptionText = uiState.description,
         groupMemberNumber = uiState.maxUserNum,
         canSubmitStudy = uiState.canSubmitStudy && !uiState.isLoading,
-        snackBarHostState = snackBarHostState,
         onNavigationButtonClick = onNavigationButtonClick,
         onTitleTextChange = viewmodel::onNameChanged,
         onDescriptionTextChange = viewmodel::onDescriptionChanged,
@@ -74,7 +70,7 @@ internal fun CreateStudyScreen(
 
     uiState.snackBarMessage?.let { message ->
         LaunchedEffect(message) {
-            snackBarHostState.showSnackbar(message)
+            onShowErrorSnackbar(Exception(message))
             viewmodel.onSnackBarShown()
         }
     }
@@ -90,7 +86,6 @@ private fun CreateStudyScreen(
     descriptionText: String,
     groupMemberNumber: String,
     canSubmitStudy: Boolean,
-    snackBarHostState: SnackbarHostState,
     onNavigationButtonClick: () -> Unit,
     onTitleTextChange: (String) -> Unit,
     onDescriptionTextChange: (String) -> Unit,
@@ -108,7 +103,6 @@ private fun CreateStudyScreen(
                 onNavigationButtonClick = onNavigationButtonClick,
             )
         },
-        snackbarHost = { SnackbarHost(snackBarHostState) },
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -187,7 +181,6 @@ private fun CreateStudyScreenPreview() {
             descriptionText = "",
             groupMemberNumber = "",
             canSubmitStudy = false,
-            snackBarHostState = remember { SnackbarHostState() },
             onNavigationButtonClick = {},
             onTitleTextChange = {},
             onDescriptionTextChange = {},

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -57,10 +55,10 @@ fun DetailStudyScreen(
     onDeleteStudyGroupSuccess: () -> Unit,
     onLeaveStudyGroupSuccess: () -> Unit,
     onEditStudyGroupButtonClick: (String) -> Unit,
-    viewModel: DetailStudyViewModel = hiltViewModel(),
-    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
     onCategoryClick: (String, String) -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
+    viewModel: DetailStudyViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -74,7 +72,6 @@ fun DetailStudyScreen(
         currentUserId = uiState.userId,
         email = uiState.email,
         isEmailValid = uiState.isEmailValid,
-        snackBarHostState = snackBarHostState,
         onNavigationButtonClick = onNavigationButtonClick,
         onCreateCategoryButtonClick = onCreateCategoryButtonClick,
         onCategoryClick = onCategoryClick,
@@ -100,7 +97,7 @@ fun DetailStudyScreen(
     uiState.errorMessageId?.let { errorMessageId ->
         val errorMessage = stringResource(errorMessageId)
         LaunchedEffect(errorMessageId) {
-            snackBarHostState.showSnackbar(errorMessage)
+            onShowErrorSnackbar(Exception(errorMessage))
             viewModel.shownErrorMessage()
         }
     }
@@ -128,7 +125,6 @@ fun DetailStudyScreen(
     currentUserId: String?,
     email: String?,
     isEmailValid: Boolean,
-    snackBarHostState: SnackbarHostState,
     onNavigationButtonClick: () -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
     onCategoryClick: (String, String) -> Unit,
@@ -201,9 +197,6 @@ fun DetailStudyScreen(
                     )
                 }
             }
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = snackBarHostState)
         },
     ) { innerPadding ->
         if (currentGroup != null && owner != null) {
@@ -333,7 +326,6 @@ private fun DetailStudyScreenPreview() {
                 studyGroups = listOf("1"),
             ),
             currentUserId = "1",
-            snackBarHostState = SnackbarHostState(),
             onNavigationButtonClick = {},
             onCreateCategoryButtonClick = { _, _ -> },
             onCategoryClick = { _, _ -> },

--- a/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
+++ b/feature/study/src/main/java/kr/boostcamp_2024/course/study/presentation/DetailStudyScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -57,6 +59,7 @@ fun DetailStudyScreen(
     onEditStudyGroupButtonClick: (String) -> Unit,
     onCreateCategoryButtonClick: (String?, String?) -> Unit,
     onCategoryClick: (String, String) -> Unit,
+    snackbarHostState: SnackbarHostState,
     onShowErrorSnackbar: (Throwable) -> Unit,
     viewModel: DetailStudyViewModel = hiltViewModel(),
 ) {
@@ -82,6 +85,7 @@ fun DetailStudyScreen(
         onLeaveStudyGroupClick = viewModel::deleteUserFromStudyGroup,
         onEmailChange = viewModel::onEmailChange,
         resetEmail = viewModel::resetEmail,
+        snackbarHostState = snackbarHostState,
     )
 
     if (uiState.isLoading) {
@@ -135,6 +139,7 @@ fun DetailStudyScreen(
     onLeaveStudyGroupClick: () -> Unit,
     onEmailChange: (String) -> Unit,
     resetEmail: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     var selectedScreenIndex by remember { mutableIntStateOf(0) }
     val screenList = listOf(DetailScreenRoute, GroupScreenRoute)
@@ -198,6 +203,7 @@ fun DetailStudyScreen(
                 }
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         if (currentGroup != null && owner != null) {
             Box(


### PR DESCRIPTION
### 👩‍🌾 진행한 작업
- 모든 화면에서 `snackbarHostState`를 관리하고 있어 매 화면마다 snackbar를 띄우는 코드 반복
- 가장 상위 composable로 `snackbarHostState를 hoisting하여 재활용 작업`

### 📷 작업 결과(사진)

<img width="249" alt="스크린샷 2025-01-28 오후 9 01 01" src="https://github.com/user-attachments/assets/0f6a6a79-3e18-4dc1-a519-af00c78f80b8" />

### 🗣️ 공유할 내용
#### 1. 별도의 예외 처리는 진행하지 않았습니다.

예외 처리 부분은 `일영 & 영민`님이 맡으신 부분이랑 작업이 겹칠 것 같아 따로 처리하지 않았습니다. 기존에 <b>string resource id</b>를 활용해 snackbar를 띄우는 부분에 임시로 `Exception`으로 감싼 `Throwable`을 던져 주도록 처리했습니다.

```kotlin
uiState.errorMessage?.let { errorMessage ->
    LaunchedEffect(errorMessage) {
        onShowErrorSnackbar(Exception(errorMessage)) // 임시로 Exception으로 감싸서 처리
        quizResultViewModel.shownErrorMessage()
    }
}
```

#### 2. snackbar가 뜨는 위치와 관련해 논의할 부분이 있습니다!

~~기존에는 각 화면 속 <b>Scaffold</b>에 `sanckbarHost`를 연결해주었기 때문에 아래에 navigationBottomBar나 FAB가 있으면 그 위에 snackbar가 띄워졌습니다. 하지만 가장 상위 composable에서 snackbar를 띄우면서 navigationBottomBar, FAB 위에 snackbar가 띄워지더라고요!~~

~~이 부분은 다른 분들의 생각도 듣고 싶어 추가 작업은 하지 않았습니다. 다들 기존 위치가 더 나은지, 아니면 지금도 괜찮은지 의견 남겨주세요!~~

|기존|수정 버전|
|:-----:|:----:|
|<img width="250" alt="스크린샷 2025-01-28 오후 9 13 14" src="https://github.com/user-attachments/assets/6f88aba5-0463-4b81-9c48-86c1424032b8" />|<img width="250" alt="스크린샷 2025-01-28 오후 9 01 01" src="https://github.com/user-attachments/assets/0f6a6a79-3e18-4dc1-a519-af00c78f80b8" />|

> **최종: 기존 방식으로 snackbar 띄우도록 작업 완료했습니다!**

#### 3. 이전 회의에서 언급했던 관련 정리글 공유드립니다!
1. snackbarHostState
2. string resource

위 두 가지를 `nowInAndroid`, `droidKnight`에서는 어떻게 관리하고 있는지에 대해 찾아보고 저희 팀에서 적용할 수 있는 것들을 정리한 글입니다! 이전 회의에서 살짝 언급했었는데, 정리된 링크 공유드립니다!😊
[- refactoring) snackbarHostState 재활용 및 string resource 관리](https://www.notion.so/refactoring-snackbarHostState-string-resource-09e3f4ba4f0042c7962e8d3cfd009451?pvs=4)




closed #203
